### PR TITLE
Make `sanitized` a variable suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ presets:
       ignoreerrors: True
 
     output_options:
-      output_directory: "{youtube_tv_shows_directory}/{sanitized_tv_show_name}"
+      output_directory: "{youtube_tv_shows_directory}/{tv_show_name_sanitized}"
       file_name: "{episode_name}.{ext}"
       thumbnail_name: "{episode_name}.jpg"
       maintain_download_archive: True
@@ -116,7 +116,7 @@ presets:
 
     overrides:
       youtube_tv_shows_directory: "/path/to/youtube_tv_shows"
-      episode_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {sanitized_title}"
+      episode_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {title_sanitized}"
 ```
 
 #### subscription.yaml
@@ -130,7 +130,8 @@ john_smith_archive:
   youtube:
     channel_id: "UCsvn_Po0SmunchJYtttWpOxMg"
   # Any user-defined override variables will automatically create a `_sanitized`
-  # variable name, which is safe to use for file names and paths
+  # variable name, which is safe to use for file names and paths.
+  # In this example, `tv_show_name` will produce `tv_show_name_sanitized` 
   overrides:
     tv_show_name: "John /\ Smith"
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,9 +10,9 @@ presets:
     ytdl_options:
       format: 'bestaudio[ext=mp3]'
     output_options:
-      output_directory: "/tmp/{sanitized_artist}"
-      file_name: "[{album_year}] {sanitized_album}/{track_number_padded} - {sanitized_title}.{ext}"
-      thumbnail_name: "[{album_year}] {sanitized_album}/folder.jpg"
+      output_directory: "/tmp/{artist_sanitized}"
+      file_name: "[{album_year}] {album_sanitized}/{track_number_padded} - {title_sanitized}.{ext}"
+      thumbnail_name: "[{album_year}] {album_sanitized}/folder.jpg"
       maintain_download_archive: True
     convert_thumbnail:
       to: "jpg"
@@ -43,7 +43,7 @@ presets:
     # We set both with {music_video_name}, which is a variable we define in
     # the overrides section further below to represent consistent naming format.
     output_options:
-      output_directory: "{music_video_directory}/{sanitized_artist}"
+      output_directory: "{music_video_directory}/{artist_sanitized}"
       file_name: "{music_video_name}.{ext}"
       thumbnail_name: "{music_video_name}.jpg"
 
@@ -69,7 +69,7 @@ presets:
     # here, which gets reused above for the video, thumbnail, and NFO file.
     overrides:
       music_video_directory: "path/to/Music Videos"
-      music_video_name: "{sanitized_artist} - {sanitized_title}"
+      music_video_name: "{artist_sanitized} - {title_sanitized}"
 
     # It is not always ideal to download all of an artist's music videos.
     # Maybe you only like one song of theirs. We can reuse our preset above
@@ -119,4 +119,4 @@ presets:
       tags:
         title: "{tv_show_name}"
     overrides:
-      output_file_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {sanitized_title}"
+      output_file_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {title_sanitized}"

--- a/docker/root/defaults/config.yaml
+++ b/docker/root/defaults/config.yaml
@@ -35,7 +35,7 @@ presets:
 
     overrides:
       music_video_directory: "/music_videos"
-      music_video_name: "{sanitized_artist} - {sanitized_title}"
+      music_video_name: "{artist_sanitized} - {title_sanitized}"
       # artist: # FILL THIS OUT IN THE SUBSCRIPTION
 
   #############################################################################

--- a/examples/kodi_music_videos_config.yaml
+++ b/examples/kodi_music_videos_config.yaml
@@ -33,7 +33,7 @@ presets:
     # We set both with {music_video_name}, which is a variable we define in
     # the overrides section further below to represent consistent naming format.
     output_options:
-      output_directory: "{music_video_directory}/{sanitized_artist}"
+      output_directory: "{music_video_directory}/{artist_sanitized}"
       file_name: "{music_video_name}.{ext}"
       thumbnail_name: "{music_video_name}.jpg"
 
@@ -59,7 +59,7 @@ presets:
     # here, which gets reused above for the video, thumbnail, and NFO file.
     overrides:
       music_video_directory: "path/to/Music Videos"
-      music_video_name: "{sanitized_artist} - {sanitized_title}"
+      music_video_name: "{artist_sanitized} - {title_sanitized}"
 
   # It is not always ideal to download all of an artist's music videos.
   # Maybe you only like one song of theirs. We can reuse our preset above

--- a/examples/kodi_music_videos_subscriptions.yaml
+++ b/examples/kodi_music_videos_subscriptions.yaml
@@ -19,9 +19,9 @@ john_smith:
     playlist_id: "UCsvn_Po0SmunchJYtttWpOxMg"
 
   # Overrides can be defined per-subscription. If you noticed, we used {artist}
-  # and {sanitized_artist} in our "yt_music_video" preset. We intended to reserve
+  # and {artist_sanitized} in our "yt_music_video" preset. We intended to reserve
   # that variable to be defined for each individual subscription. Each override
-  # defined here will create a 'sanitized_' version that is safe for file systems.
+  # defined here will create a '_sanitized' version that is safe for file systems.
   #
   # A note for Kodi music videos, it is important to make sure your artist name
   # exactly matches how it is formatted in Kodi itself, otherwise it will be

--- a/examples/kodi_tv_shows_config.yaml
+++ b/examples/kodi_tv_shows_config.yaml
@@ -50,7 +50,7 @@ presets:
     # store previously downloaded video ids to tell YTDL not to re-download
     # them on a successive invocation.
     output_options:
-      output_directory: "{youtube_tv_shows_directory}/{sanitized_tv_show_name}"
+      output_directory: "{youtube_tv_shows_directory}/{tv_show_name_sanitized}"
       file_name: "{episode_name}.{ext}"
       thumbnail_name: "{episode_name}.jpg"
       maintain_download_archive: True
@@ -87,7 +87,7 @@ presets:
     # which gets reused above for the video, thumbnail, and NFO file.
     overrides:
       youtube_tv_shows_directory: "/path/to/youtube_tv_shows"
-      episode_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {sanitized_title}"
+      episode_name: "Season {upload_year}/s{upload_year}.e{upload_month_padded}{upload_day_padded} - {title_sanitized}"
 
   ###############################################################################
   # LEVEL 2 - RECENT ARCHIVE

--- a/examples/kodi_tv_shows_subscriptions.yaml
+++ b/examples/kodi_tv_shows_subscriptions.yaml
@@ -19,10 +19,10 @@ john_smith_archive:
     channel_id: "UCsvn_Po0SmunchJYtttWpOxMg"
 
   # Overrides can be defined per-subscription. If you noticed, we used
-  # {tv_show_name} and {sanitized_tv_show_name} in our "yt_channel_as_tv"
+  # {tv_show_name} and {tv_show_name_sanitized} in our "yt_channel_as_tv"
   # preset. We intended to reserve that variable to be defined for each
   # individual subscription. Each override defined here will create a
-  # 'sanitized_' version that is safe for file systems.
+  # '_sanitized' version that is safe for file systems.
   overrides:
     tv_show_name: "John /\ Smith"
 

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -47,7 +47,7 @@ class Overrides(DictFormatterValidator):
          my_example_preset:
            overrides:
              output_directory: "/path/to/media"
-             custom_file_name: "{upload_year}.{upload_month_padded}.{upload_day_padded}.{sanitized_title}"
+             custom_file_name: "{upload_year}.{upload_month_padded}.{upload_day_padded}.{title_sanitized}"
 
            # Then use the override variables in the output options
            output_options:
@@ -63,14 +63,14 @@ class Overrides(DictFormatterValidator):
     def __init__(self, name, value):
         super().__init__(name, value)
         for key in self._keys:
-            sanitized_key_name = f"sanitized_{key}"
+            key_name_sanitized = f"{key}_sanitized"
             # First, sanitize the format string
-            self._value[sanitized_key_name] = sanitize_filename(self._value[key].format_string)
+            self._value[key_name_sanitized] = sanitize_filename(self._value[key].format_string)
 
             # Then, convert it into a StringFormatterValidator
-            self._value[sanitized_key_name] = StringFormatterValidator(
+            self._value[key_name_sanitized] = StringFormatterValidator(
                 name="__should_never_fail__",
-                value=self._value[sanitized_key_name],
+                value=self._value[key_name_sanitized],
             )
 
     def apply_formatter(
@@ -99,9 +99,9 @@ class OutputOptions(StrictDictValidator):
            output_options:
              # required
              output_directory: "/path/to/videos_or_music"
-             file_name: "{sanitized_title}.{ext}"
+             file_name: "{title_sanitized}.{ext}"
              # optional
-             thumbnail_name: "{sanitized_title}.{thumbnail_ext}"
+             thumbnail_name: "{title_sanitized}.{thumbnail_ext}"
              maintain_download_archive: True
              keep_files_before: now
              keep_files_after: 19000101

--- a/src/ytdl_sub/entries/variables/entry_variables.py
+++ b/src/ytdl_sub/entries/variables/entry_variables.py
@@ -60,7 +60,7 @@ class EntryVariables(SourceVariables):
         return self.kwargs("title")
 
     @property
-    def sanitized_title(self) -> str:
+    def title_sanitized(self) -> str:
         """
         Returns
         -------

--- a/src/ytdl_sub/entries/variables/soundcloud_variables.py
+++ b/src/ytdl_sub/entries/variables/soundcloud_variables.py
@@ -44,7 +44,7 @@ class SoundcloudVariables(EntryVariables):
         return self.title
 
     @property
-    def sanitized_album(self) -> str:
+    def album_sanitized(self) -> str:
         """
         Returns
         -------

--- a/src/ytdl_sub/plugins/nfo_tags.py
+++ b/src/ytdl_sub/plugins/nfo_tags.py
@@ -22,7 +22,7 @@ class NfoTagsOptions(PluginOptions):
        presets:
          my_example_preset:
            nfo:
-            nfo_name: "{sanitized_title}.nfo"
+            nfo_name: "{title_sanitized}.nfo"
             nfo_root: "episodedetails"
             tags:
               title: "{title}"

--- a/tests/unit/entries/conftest.py
+++ b/tests/unit/entries/conftest.py
@@ -86,7 +86,7 @@ def mock_entry_to_dict(
     return {
         "uid": uid,
         "title": title,
-        "sanitized_title": title,
+        "title_sanitized": title,
         "ext": ext,
         "extractor": extractor,
         "upload_date": upload_date,
@@ -136,7 +136,7 @@ def validate_entry_properties(
     def _validate_entry_properties(entry: Entry):
         assert entry.uid == uid
         assert entry.title == title
-        assert entry.sanitized_title == title
+        assert entry.title_sanitized == title
         assert entry.upload_date == upload_date
         assert entry.upload_year == upload_year
         assert entry.ext == ext

--- a/tests/unit/entries/test_soundcloud_entries.py
+++ b/tests/unit/entries/test_soundcloud_entries.py
@@ -44,7 +44,7 @@ def mock_soundcloud_track_to_dict(
             "track_number": track_number,
             "track_number_padded": track_number_padded,
             "album": title,
-            "sanitized_album": title,
+            "album_sanitized": title,
             "album_year": upload_year,
             "track_count": track_count,
         }
@@ -76,7 +76,7 @@ def validate_soundcloud_track_properties(
         assert soundcloud_track.track_number == track_number
         assert soundcloud_track.track_number_padded == track_number_padded
         assert soundcloud_track.album == title
-        assert soundcloud_track.sanitized_album == title
+        assert soundcloud_track.album_sanitized == title
         assert soundcloud_track.album_year == upload_year
         assert soundcloud_track.track_count == track_count
         assert soundcloud_track.is_premiere() == is_premiere


### PR DESCRIPTION
Instead of a prefix, for better doc sorting.
https://github.com/jmbannon/ytdl-sub/issues/33