### PR TITLE
[BACKEND] Move files from working to output directory instead of copying

### DIFF
--- a/src/ytdl_sub/downloaders/youtube/split_video.py
+++ b/src/ytdl_sub/downloaders/youtube/split_video.py
@@ -183,7 +183,7 @@ class YoutubeSplitVideoDownloader(
 
             # Copy the original vid thumbnail to the working directory with the new uid. This so
             # downstream logic thinks this split video has its own thumbnail
-            FileHandler.copy(
+            FileHandler.move(
                 src_file_path=entry.get_download_thumbnail_path(),
                 dst_file_path=Path(self.working_directory) / f"{new_uid}.{entry.thumbnail_ext}",
             )

--- a/src/ytdl_sub/downloaders/youtube/split_video.py
+++ b/src/ytdl_sub/downloaders/youtube/split_video.py
@@ -183,7 +183,7 @@ class YoutubeSplitVideoDownloader(
 
             # Copy the original vid thumbnail to the working directory with the new uid. This so
             # downstream logic thinks this split video has its own thumbnail
-            FileHandler.move(
+            FileHandler.copy(
                 src_file_path=entry.get_download_thumbnail_path(),
                 dst_file_path=Path(self.working_directory) / f"{new_uid}.{entry.thumbnail_ext}",
             )

--- a/src/ytdl_sub/subscriptions/subscription.py
+++ b/src/ytdl_sub/subscriptions/subscription.py
@@ -148,7 +148,7 @@ class Subscription:
             and self.downloader_class.supports_download_archive
         )
 
-    def _copy_entry_files_to_output_directory(
+    def _move_entry_files_to_output_directory(
         self, entry: Entry, entry_metadata: Optional[FileMetadata] = None
     ):
         """
@@ -288,7 +288,7 @@ class Subscription:
                     if optional_plugin_entry_metadata:
                         entry_metadata.extend(optional_plugin_entry_metadata)
 
-                self._copy_entry_files_to_output_directory(
+                self._move_entry_files_to_output_directory(
                     entry=entry, entry_metadata=entry_metadata
                 )
 

--- a/src/ytdl_sub/utils/file_handler.py
+++ b/src/ytdl_sub/utils/file_handler.py
@@ -177,6 +177,18 @@ class FileHandler:
         return self._file_handler_transaction_log
 
     @classmethod
+    def copy(cls, src_file_path: Union[str, Path], dst_file_path: Union[str, Path]):
+        """
+        Parameters
+        ----------
+        src_file_path
+            Source file
+        dst_file_path
+            Destination file
+        """
+        shutil.copyfile(src=src_file_path, dst=dst_file_path)
+
+    @classmethod
     def move(cls, src_file_path: Union[str, Path], dst_file_path: Union[str, Path]):
         """
         Parameters

--- a/src/ytdl_sub/utils/file_handler.py
+++ b/src/ytdl_sub/utils/file_handler.py
@@ -1,6 +1,6 @@
 import os
+import shutil
 from pathlib import Path
-from shutil import copyfile
 from typing import Any
 from typing import Dict
 from typing import List
@@ -177,7 +177,7 @@ class FileHandler:
         return self._file_handler_transaction_log
 
     @classmethod
-    def copy(cls, src_file_path: Union[str, Path], dst_file_path: Union[str, Path]):
+    def move(cls, src_file_path: Union[str, Path], dst_file_path: Union[str, Path]):
         """
         Parameters
         ----------
@@ -186,7 +186,7 @@ class FileHandler:
         dst_file_path
             Destination file
         """
-        copyfile(src=src_file_path, dst=dst_file_path)
+        shutil.move(src=src_file_path, dst=dst_file_path)
 
     @classmethod
     def delete(cls, file_path: Union[str, Path]):
@@ -199,7 +199,7 @@ class FileHandler:
         if os.path.isfile(file_path):
             os.remove(file_path)
 
-    def copy_file_to_output_directory(
+    def move_file_to_output_directory(
         self, file_name: str, output_file_name: str, file_metadata: Optional[FileMetadata] = None
     ):
         """
@@ -223,7 +223,7 @@ class FileHandler:
         if not self.dry_run:
             output_file_path = Path(self.output_directory) / output_file_name
             os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
-            self.copy(
+            self.move(
                 src_file_path=Path(self.working_directory) / file_name,
                 dst_file_path=output_file_path,
             )

--- a/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
+++ b/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
@@ -321,7 +321,7 @@ class EnhancedDownloadArchive:
         a. self._load()
            Checks the output directory to see if an existing enhanced download archive file
            exists. If so, load it into the class. Otherwise, initialize an empty instance of one.
-        b. self._copy_to_working_directory()
+        b. self._move_to_working_directory()
            If the download archive was loaded successfully, create a ytdl download archive in the
            working directory. This will let ytdl know which files are already downloaded.
     2. ( Perform the ytdlp download using a download archive with the same name )
@@ -576,7 +576,7 @@ class EnhancedDownloadArchive:
         if entry:
             self.mapping.add_entry(entry=entry, entry_file_path=output_file_name)
 
-        self._file_handler.copy_file_to_output_directory(
+        self._file_handler.move_file_to_output_directory(
             file_name=file_name, file_metadata=file_metadata, output_file_name=output_file_name
         )
 


### PR DESCRIPTION
Made sense before the enhanced download archive, but now, copying is a waste of space