### PR TITLE
[BUGFIX] Fix youtube url validator for channels without 'c', 'channel' or 'user'

### DIFF
--- a/src/ytdl_sub/validators/url_validator.py
+++ b/src/ytdl_sub/validators/url_validator.py
@@ -114,6 +114,7 @@ class YoutubeChannelUrlValidator(StringValidator):
         - https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw
         - https://www.youtube.com/user/username
         - https://www.youtube.com/c/channel_name
+        - https://youtube.com/channel_name
         """
         # If the url doesn't contain youtube, assume it is invalid
         if "youtube.com" not in url:
@@ -125,11 +126,14 @@ class YoutubeChannelUrlValidator(StringValidator):
 
         query = urlparse(url)
         if query.hostname in ("youtube.com", "www.youtube.com"):
+            query_path_split = query.path.split("/")
             if any(query.path.startswith(qpath) for qpath in ("/channel/", "/user/", "/c/")):
                 # Ensure there is "/path/id".split('/') = ['', 'path', 'id'] at least three
-                query_path_split = query.path.split("/")
                 if len(query_path_split) < 3 or len(query_path_split[2]) == 0:
                     return None
+                return f"https://youtube.com{query.path}"
+            elif len(query_path_split) == 2 and len(query_path_split[1]) > 0:
+                # For channels that do not feature a 'c' or 'channel', ensure length of channel string is at least one
                 return f"https://youtube.com{query.path}"
 
         return None

--- a/src/ytdl_sub/validators/url_validator.py
+++ b/src/ytdl_sub/validators/url_validator.py
@@ -132,8 +132,9 @@ class YoutubeChannelUrlValidator(StringValidator):
                 if len(query_path_split) < 3 or len(query_path_split[2]) == 0:
                     return None
                 return f"https://youtube.com{query.path}"
-            elif len(query_path_split) == 2 and len(query_path_split[1]) > 0:
-                # For channels that do not feature a 'c' or 'channel', ensure length of channel string is at least one
+            if len(query_path_split) == 2 and len(query_path_split[1]) > 0:
+                # For channels that do not feature a 'c' or 'channel'
+                # Ensure length of channel string is at least one
                 return f"https://youtube.com{query.path}"
 
         return None

--- a/tests/unit/validators/test_url_validator.py
+++ b/tests/unit/validators/test_url_validator.py
@@ -105,6 +105,10 @@ class TestYoutubeChannelUrlValidator:
                 "https://www.youtube.com/user/videogamedunkey",
                 "https://youtube.com/user/videogamedunkey",
             ),
+            (
+                "https://youtube.com/extracredits",
+                "https://youtube.com/extracredits",
+            ),
         ],
     )
     def test_youtube_channel_url_validator_success(self, url, expected_url):
@@ -117,7 +121,6 @@ class TestYoutubeChannelUrlValidator:
             "www.youtube.com/cha/UCuAXFkgsw1L7xaCfnd5JJOw",
             "www.nopetube.com/channel/asdfdsf",
             "www.youtube.com/channel/",
-            "www.youtube.com/channel",
             "www.youtube.com/channell/asdfasdf",
         ],
     )


### PR DESCRIPTION
This fixes issue #106

I thought Id at least give it a shot, after your comment in issue #106.

I decided to remove the bad_url match for "www.youtube.com/channel" as it could technically be a good url with these changes, as long as there is a channel out there named "channel".

Id be very happy to change anything youd like to change.