### PR TITLE
[FEATURE] Add reversed date variables

### DIFF
--- a/src/ytdl_sub/entries/variables/entry_variables.py
+++ b/src/ytdl_sub/entries/variables/entry_variables.py
@@ -10,6 +10,12 @@ from ytdl_sub.entries.base_entry import BaseEntry
 # pylint: disable=no-member
 
 
+def _pad(num):
+    if num < 10:
+        return f"0{num}"
+    return str(num)
+
+
 class SourceVariables:
     """
     Source variables are ``{variables}`` that contain metadata from downloaded media.
@@ -143,6 +149,37 @@ class EntryVariables(SourceVariables):
         return int(str(self.upload_year)[-2:])
 
     @property
+    def upload_year_truncated_reversed(self) -> int:
+        """
+        Returns
+        -------
+        int
+            The upload year truncated, but reversed using ``100 - {upload_year_truncated}``, i.e.
+            2022 returns ``100 - 22`` = ``78``
+        """
+        return 100 - self.upload_year_truncated
+
+    @property
+    def upload_month_reversed(self) -> int:
+        """
+        Returns
+        -------
+        int
+            The upload month, but reversed using ``13 - {upload_month}``, i.e. March returns ``10``
+        """
+        return 13 - self.upload_month
+
+    @property
+    def upload_month_reversed_padded(self) -> str:
+        """
+        Returns
+        -------
+        str
+            The reversed upload month, but padded. i.e. November returns "02"
+        """
+        return _pad(self.upload_month_reversed)
+
+    @property
     def upload_month_padded(self) -> str:
         """
         Returns
@@ -181,6 +218,35 @@ class EntryVariables(SourceVariables):
             The upload day as an integer (no padding).
         """
         return int(self.upload_day_padded.lstrip("0"))
+
+    @property
+    def upload_day_reversed(self) -> int:
+        """
+        Returns
+        -------
+        int
+            The upload day, but reversed using ``{total_days_in_month} + 1 - {upload_day}``,
+            i.e. August 8th would have upload_day_reversed of ``31 + 1 - 8`` = ``24``
+        """
+        total_days_in_month: int = 30
+        if self.upload_month in [1, 3, 5, 7, 8, 10, 12]:
+            total_days_in_month = 31
+        elif self.upload_month == 2:
+            total_days_in_month = 28
+            if self.upload_year % 4 == 0:  # leap year
+                total_days_in_month = 29
+
+        return total_days_in_month + 1 - self.upload_day
+
+    @property
+    def upload_day_reversed_padded(self) -> str:
+        """
+        Returns
+        -------
+        str
+            The reversed upload day, but padded. i.e. August 30th returns "02".
+        """
+        return _pad(self.upload_day_reversed)
 
     @property
     def upload_date_standardized(self) -> str:

--- a/tests/unit/entries/conftest.py
+++ b/tests/unit/entries/conftest.py
@@ -4,12 +4,6 @@ from ytdl_sub.entries.entry import Entry
 from ytdl_sub.validators.string_formatter_validators import StringFormatterValidator
 
 
-def _pad(num):
-    if num < 10:
-        return f"0{num}"
-    return str(num)
-
-
 @pytest.fixture
 def uid():
     return "abc123"
@@ -26,23 +20,8 @@ def title():
 
 
 @pytest.fixture
-def upload_year():
-    return 2021
-
-
-@pytest.fixture
-def upload_month():
-    return 1
-
-
-@pytest.fixture
-def upload_day():
-    return 12
-
-
-@pytest.fixture
-def upload_date(upload_year, upload_month, upload_day):
-    return f"{upload_year}{_pad(upload_month)}{_pad(upload_day)}"
+def upload_date():
+    return "20210112"
 
 
 @pytest.fixture
@@ -72,10 +51,7 @@ def mock_entry_to_dict(
     ext,
     extractor,
     upload_date,
-    upload_year,
     thumbnail_ext,
-    upload_month,
-    upload_day,
 ):
     return {
         "uid": uid,
@@ -84,13 +60,18 @@ def mock_entry_to_dict(
         "ext": ext,
         "extractor": extractor,
         "upload_date": upload_date,
-        "upload_date_standardized": f"{upload_year}-{_pad(upload_month)}-{_pad(upload_day)}",
-        "upload_year": upload_year,
+        "upload_date_standardized": "2021-01-12",
+        "upload_year": 2021,
         "upload_year_truncated": 21,
-        "upload_month": upload_month,
-        "upload_month_padded": _pad(upload_month),
-        "upload_day": upload_day,
-        "upload_day_padded": _pad(upload_day),
+        "upload_year_truncated_reversed": 79,
+        "upload_month": 1,
+        "upload_month_padded": "01",
+        "upload_month_reversed": 12,
+        "upload_month_reversed_padded": "12",
+        "upload_day": 12,
+        "upload_day_padded": "12",
+        "upload_day_reversed": 20,
+        "upload_day_reversed_padded": "20",
         "thumbnail_ext": thumbnail_ext,
     }
 
@@ -110,33 +91,6 @@ def mock_entry_kwargs(uid, title, ext, upload_date, extractor, download_thumbnai
 @pytest.fixture
 def mock_entry(mock_entry_kwargs):
     return Entry(entry_dict=mock_entry_kwargs, working_directory=".")
-
-
-@pytest.fixture
-def validate_entry_properties(
-    uid,
-    title,
-    upload_date,
-    upload_year,
-    ext,
-    extractor,
-    thumbnail_ext,
-    download_file_name,
-    download_thumbnail_name,
-):
-    def _validate_entry_properties(entry: Entry):
-        assert entry.uid == uid
-        assert entry.title == title
-        assert entry.title_sanitized == title
-        assert entry.upload_date == upload_date
-        assert entry.upload_year == upload_year
-        assert entry.ext == ext
-        assert entry.thumbnail_ext == thumbnail_ext
-        assert entry.extractor == extractor
-
-        return True
-
-    return _validate_entry_properties
 
 
 @pytest.fixture

--- a/tests/unit/entries/test_entry.py
+++ b/tests/unit/entries/test_entry.py
@@ -2,13 +2,6 @@ import pytest
 
 
 class TestEntry(object):
-    def test_entry_properties(
-        self,
-        mock_entry,
-        validate_entry_properties,
-    ):
-        assert validate_entry_properties(mock_entry)
-
     def test_entry_to_dict(self, mock_entry, mock_entry_to_dict):
         assert mock_entry.to_dict() == mock_entry_to_dict
 
@@ -24,3 +17,22 @@ class TestEntry(object):
         assert mock_entry.kwargs_contains(key) is False
         with pytest.raises(KeyError, match=expected_error_msg):
             mock_entry.kwargs(key)
+
+    @pytest.mark.parametrize(
+        "upload_date, year_rev, month_rev, day_rev, month_rev_pad, day_rev_pad",
+        [
+            ("20000228", 100, 11, 2, "11", "02"),
+            ("20200808", 80, 5, 24, "05", "24"),
+        ],
+    )
+    def test_entry_reverse_variables(
+        self, mock_entry, upload_date, year_rev, month_rev, day_rev, month_rev_pad, day_rev_pad
+    ):
+        mock_entry._kwargs["upload_date"] = upload_date
+
+        assert mock_entry.upload_year_truncated_reversed == year_rev
+        assert mock_entry.upload_month_reversed == month_rev
+        assert mock_entry.upload_day_reversed == day_rev
+
+        assert mock_entry.upload_month_reversed_padded == month_rev_pad
+        assert mock_entry.upload_day_reversed_padded == day_rev_pad

--- a/tests/unit/entries/test_soundcloud_entries.py
+++ b/tests/unit/entries/test_soundcloud_entries.py
@@ -4,49 +4,21 @@ from ytdl_sub.entries.soundcloud import SoundcloudTrack
 
 
 @pytest.fixture
-def track_number():
-    return 1
-
-
-@pytest.fixture
-def track_number_padded():
-    return "01"
-
-
-@pytest.fixture
-def track_count():
-    return 1
-
-
-@pytest.fixture
 def url():
     return "soundcloud.com/artist/track-asdfasdf"
 
 
 @pytest.fixture
-def is_premiere():
-    return False
-
-
-@pytest.fixture
-def mock_soundcloud_track_to_dict(
-    mock_entry_to_dict,
-    title,
-    upload_year,
-    track_number,
-    track_number_padded,
-    is_premiere,
-    track_count,
-):
+def mock_soundcloud_track_to_dict(mock_entry_to_dict):
     return dict(
         mock_entry_to_dict,
         **{
-            "track_number": track_number,
-            "track_number_padded": track_number_padded,
-            "album": title,
-            "album_sanitized": title,
-            "album_year": upload_year,
-            "track_count": track_count,
+            "track_number": 1,
+            "track_number_padded": "01",
+            "album": mock_entry_to_dict["title"],
+            "album_sanitized": mock_entry_to_dict["title_sanitized"],
+            "album_year": mock_entry_to_dict["upload_year"],
+            "track_count": 1,
         }
     )
 
@@ -61,39 +33,7 @@ def mock_soundcloud_track(mock_soundcloud_track_kwargs):
     return SoundcloudTrack(entry_dict=mock_soundcloud_track_kwargs, working_directory=".")
 
 
-@pytest.fixture
-def validate_soundcloud_track_properties(
-    validate_entry_properties,
-    title,
-    upload_year,
-    track_number,
-    track_number_padded,
-    is_premiere,
-    track_count,
-):
-    def _validate_soundcloud_track_properties(soundcloud_track: SoundcloudTrack):
-        assert validate_entry_properties(soundcloud_track)
-        assert soundcloud_track.track_number == track_number
-        assert soundcloud_track.track_number_padded == track_number_padded
-        assert soundcloud_track.album == title
-        assert soundcloud_track.album_sanitized == title
-        assert soundcloud_track.album_year == upload_year
-        assert soundcloud_track.track_count == track_count
-        assert soundcloud_track.is_premiere() == is_premiere
-
-        return True
-
-    return _validate_soundcloud_track_properties
-
-
 class TestSoundcloudTrack(object):
-    def test_properties(
-        self,
-        mock_soundcloud_track,
-        validate_soundcloud_track_properties,
-    ):
-        assert validate_soundcloud_track_properties(mock_soundcloud_track)
-
     def test_to_dict(self, mock_soundcloud_track, mock_soundcloud_track_to_dict):
         assert mock_soundcloud_track.to_dict() == mock_soundcloud_track_to_dict
 


### PR DESCRIPTION
https://github.com/jmbannon/ytdl-sub/issues/189

Adds reverse date variables to make more recently uploaded content have a lower ordering, i.e.
`Season {upload_year_truncated_reversed} Episode {upload_month_reversed}{upload_day_reversed_padded}`

2022-01-01 -> Season 78 Episode 1231
2022-01-02 -> Season 78 Episode 1230
...
2022-12-31 -> Season 78 Episode 101
2023-01-01 -> Season 77 Episode 1231