### PR TITLE
[BACKEND] More strict validation for config files

### DIFF
--- a/examples/tv_show_config.yaml
+++ b/examples/tv_show_config.yaml
@@ -86,14 +86,15 @@ presets:
 
   # Preset to download subtitles (either by file or embedded)
   add_subtitles:
-    # Embed subtitles into the video
-    embed_subtitles: True
-    # And/or download them as a file. Uncomment to download as file:
-    # subtitles_name: "{episode_file_path}.{lang}.{subtitles_ext}"
-    # subtitles_type: "srt"
+    subtitles:
+      # Embed subtitles into the video
+      embed_subtitles: True
+      # And/or download them as a file. Uncomment to download as file:
+      # subtitles_name: "{episode_file_path}.{lang}.{subtitles_ext}"
+      # subtitles_type: "srt"
 
-    languages: "en"  # supports list of multiple languages
-    allow_auto_generated_subtitles: True  # allow auto subtitles
+      languages: "en"  # supports list of multiple languages
+      allow_auto_generated_subtitles: True  # allow auto subtitles
 
 ####################################################################################################
 

--- a/examples/tv_show_config.yaml
+++ b/examples/tv_show_config.yaml
@@ -77,6 +77,7 @@ presets:
     # "season_by_year__episode_by_download_index" if you plan to delete older videos
     output_options:
       keep_files_after: "today-{download_range}"
+      maintain_download_archive: True
 
     # Set the duration of download_range, defaults to 2 months
     overrides:

--- a/examples/tv_show_config.yaml
+++ b/examples/tv_show_config.yaml
@@ -77,7 +77,6 @@ presets:
     # "season_by_year__episode_by_download_index" if you plan to delete older videos
     output_options:
       keep_files_after: "today-{download_range}"
-      maintain_download_archive: True
 
     # Set the duration of download_range, defaults to 2 months
     overrides:

--- a/src/ytdl_sub/cli/download_args_parser.py
+++ b/src/ytdl_sub/cli/download_args_parser.py
@@ -8,7 +8,7 @@ from typing import Tuple
 from mergedeep import mergedeep
 
 from ytdl_sub.cli.main_args_parser import MainArgs
-from ytdl_sub.config.config_file import ConfigOptions
+from ytdl_sub.config.config_validator import ConfigOptions
 from ytdl_sub.utils.exceptions import InvalidDlArguments
 
 

--- a/src/ytdl_sub/config/config_file.py
+++ b/src/ytdl_sub/config/config_file.py
@@ -1,99 +1,19 @@
 import os
 from typing import Any
-from typing import Dict
-from typing import Optional
 
-import mergedeep
-
-from ytdl_sub.prebuilt_presets import PREBUILT_PRESETS
+from ytdl_sub.config.config_validator import ConfigValidator
+from ytdl_sub.config.preset import Preset
 from ytdl_sub.utils.yaml import load_yaml
-from ytdl_sub.validators.strict_dict_validator import StrictDictValidator
-from ytdl_sub.validators.validators import LiteralDictValidator
-from ytdl_sub.validators.validators import StringValidator
 
 
-class ConfigOptions(StrictDictValidator):
-    _required_keys = {"working_directory"}
-    _optional_keys = {"umask", "dl_aliases"}
-
-    def __init__(self, name: str, value: Any):
-        super().__init__(name, value)
-
-        self._working_directory = self._validate_key(
-            key="working_directory", validator=StringValidator
-        )
-        self._umask = self._validate_key_if_present(
-            key="umask", validator=StringValidator, default="022"
-        )
-        self._dl_aliases = self._validate_key_if_present(
-            key="dl_aliases", validator=LiteralDictValidator
-        )
-
-    @property
-    def working_directory(self) -> str:
-        """
-        The directory to temporarily store downloaded files before moving them into their final
-        directory.
-        """
-        return self._working_directory.value
-
-    @property
-    def umask(self) -> Optional[str]:
-        """
-        Umask (octal format) to apply to every created file. Defaults to "022".
-        """
-        return self._umask.value
-
-    @property
-    def dl_aliases(self) -> Optional[Dict[str, str]]:
-        """
-        Alias definitions to shorten ``ytdl-sub dl`` arguments. For example,
-
-        .. code-block:: yaml
-
-           configuration:
-             dl_aliases:
-               mv: "--preset yt_music_video"
-               v: "--youtube.video_url"
-
-        Simplifies
-
-        .. code-block:: bash
-
-           ytdl-sub dl --preset "yt_music_video" --youtube.video_url "youtube.com/watch?v=a1b2c3"
-
-        to
-
-        .. code-block:: bash
-
-           ytdl-sub dl --mv --v "youtube.com/watch?v=a1b2c3"
-        """
-        if self._dl_aliases:
-            return self._dl_aliases.dict
-        return {}
-
-
-class ConfigFile(StrictDictValidator):
+class ConfigFile(ConfigValidator):
     _required_keys = {"configuration", "presets"}
 
     def __init__(self, name: str, value: Any):
         super().__init__(name, value)
-        self.config_options = self._validate_key("configuration", ConfigOptions)
 
-        prebuilt_presets = PREBUILT_PRESETS
-
-        # Make sure presets is a dictionary. Will be validated in `PresetValidator`
-        self.presets = self._validate_key("presets", LiteralDictValidator)
-
-        # Ensure custom presets do not collide with prebuilt presets
-        for preset_name in self.presets.keys:
-            if preset_name in prebuilt_presets:
-                raise self._validation_exception(
-                    f"preset name '{preset_name}' conflicts with a prebuilt preset"
-                )
-
-        # Merge prebuilt presets into the config so custom presets can use them
-        mergedeep.merge(self.presets._value, prebuilt_presets)
+        for preset_name, preset_dict in self.presets.dict.items():
+            Preset.preset_partial_validate(config=self, name=preset_name, value=preset_dict)
 
     def initialize(self):
         """

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -1,0 +1,92 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from mergedeep import mergedeep
+
+from ytdl_sub.prebuilt_presets import PREBUILT_PRESETS
+from ytdl_sub.validators.strict_dict_validator import StrictDictValidator
+from ytdl_sub.validators.validators import LiteralDictValidator
+from ytdl_sub.validators.validators import StringValidator
+
+
+class ConfigOptions(StrictDictValidator):
+    _required_keys = {"working_directory"}
+    _optional_keys = {"umask", "dl_aliases"}
+
+    def __init__(self, name: str, value: Any):
+        super().__init__(name, value)
+
+        self._working_directory = self._validate_key(
+            key="working_directory", validator=StringValidator
+        )
+        self._umask = self._validate_key_if_present(
+            key="umask", validator=StringValidator, default="022"
+        )
+        self._dl_aliases = self._validate_key_if_present(
+            key="dl_aliases", validator=LiteralDictValidator
+        )
+
+    @property
+    def working_directory(self) -> str:
+        """
+        The directory to temporarily store downloaded files before moving them into their final
+        directory.
+        """
+        return self._working_directory.value
+
+    @property
+    def umask(self) -> Optional[str]:
+        """
+        Umask (octal format) to apply to every created file. Defaults to "022".
+        """
+        return self._umask.value
+
+    @property
+    def dl_aliases(self) -> Optional[Dict[str, str]]:
+        """
+        Alias definitions to shorten ``ytdl-sub dl`` arguments. For example,
+
+        .. code-block:: yaml
+
+           configuration:
+             dl_aliases:
+               mv: "--preset yt_music_video"
+               v: "--youtube.video_url"
+
+        Simplifies
+
+        .. code-block:: bash
+
+           ytdl-sub dl --preset "yt_music_video" --youtube.video_url "youtube.com/watch?v=a1b2c3"
+
+        to
+
+        .. code-block:: bash
+
+           ytdl-sub dl --mv --v "youtube.com/watch?v=a1b2c3"
+        """
+        if self._dl_aliases:
+            return self._dl_aliases.dict
+        return {}
+
+
+class ConfigValidator(StrictDictValidator):
+    _required_keys = {"configuration", "presets"}
+
+    def __init__(self, name: str, value: Any):
+        super().__init__(name, value)
+        self.config_options = self._validate_key("configuration", ConfigOptions)
+
+        # Make sure presets is a dictionary. Will be validated in `PresetValidator`
+        self.presets = self._validate_key("presets", LiteralDictValidator)
+
+        # Ensure custom presets do not collide with prebuilt presets
+        for preset_name in self.presets.keys:
+            if preset_name in PREBUILT_PRESETS:
+                raise self._validation_exception(
+                    f"preset name '{preset_name}' conflicts with a prebuilt preset"
+                )
+
+        # Merge prebuilt presets into the config so custom presets can use them
+        mergedeep.merge(self.presets._value, PREBUILT_PRESETS)

--- a/src/ytdl_sub/config/preset.py
+++ b/src/ytdl_sub/config/preset.py
@@ -128,6 +128,19 @@ class Preset(StrictDictValidator):
     # and ensure required keys are present.
     _optional_keys = PRESET_KEYS
 
+    @classmethod
+    def preset_partial_validate(cls, config: ConfigFile, name: str, value: Any) -> None:
+        cls._partial_validate_key(name, value, "output_options", OutputOptions)
+        cls._partial_validate_key(name, value, "ytdl_options", YTDLOptions)
+        cls._partial_validate_key(name, value, "overrides", Overrides)
+        for plugin_name in PluginMapping.plugins():
+            cls._partial_validate_key(
+                name,
+                value,
+                key=plugin_name,
+                validator=PluginMapping.get(plugin_name).plugin_options_type,
+            )
+
     @property
     def _source_variables(self) -> List[str]:
         return Entry.source_variables()

--- a/src/ytdl_sub/config/preset.py
+++ b/src/ytdl_sub/config/preset.py
@@ -146,7 +146,7 @@ class Preset(_PresetShell):
         if len(sources) > 1:
             raise validation_exception(
                 name=name,
-                error_message=f"Contains the sources {', '.join(sources)}' but can only have one",
+                error_message=f"Contains the sources {', '.join(sources)} but can only have one",
             )
 
         # If no sources, nothing more to validate

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -191,6 +191,8 @@ class OutputOptions(StrictDictValidator):
         if isinstance(value, dict):
             value["output_directory"] = value.get("output_directory", "placeholder")
             value["file_name"] = value.get("file_name", "placeholder")
+            # Set this to True by default in partial validate to avoid failing from keep_files
+            value["maintain_download_archive"] = value.get("maintain_download_archive", True)
         _ = cls(name, value)
 
     def __init__(self, name, value):

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -13,7 +13,6 @@ from ytdl_sub.validators.string_formatter_validators import DictFormatterValidat
 from ytdl_sub.validators.string_formatter_validators import OverridesStringFormatterValidator
 from ytdl_sub.validators.string_formatter_validators import StringFormatterValidator
 from ytdl_sub.validators.validators import BoolValidator
-from ytdl_sub.validators.validators import DictValidator
 from ytdl_sub.validators.validators import LiteralDictValidator
 
 

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -12,6 +13,7 @@ from ytdl_sub.validators.string_formatter_validators import DictFormatterValidat
 from ytdl_sub.validators.string_formatter_validators import OverridesStringFormatterValidator
 from ytdl_sub.validators.string_formatter_validators import StringFormatterValidator
 from ytdl_sub.validators.validators import BoolValidator
+from ytdl_sub.validators.validators import DictValidator
 from ytdl_sub.validators.validators import LiteralDictValidator
 
 
@@ -181,6 +183,13 @@ class OutputOptions(StrictDictValidator):
         "keep_files_before",
         "keep_files_after",
     }
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["output_directory"] = value.get("output_directory", "placeholder")
+            value["file_name"] = value.get("file_name", "placeholder")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -185,6 +185,9 @@ class OutputOptions(StrictDictValidator):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate output options
+        """
         if isinstance(value, dict):
             value["output_directory"] = value.get("output_directory", "placeholder")
             value["file_name"] = value.get("file_name", "placeholder")

--- a/src/ytdl_sub/downloaders/generic/collection_validator.py
+++ b/src/ytdl_sub/downloaders/generic/collection_validator.py
@@ -45,6 +45,9 @@ class CollectionUrlValidator(StrictDictValidator):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a YouTube collection url
+        """
         if isinstance(value, dict):
             value["url"] = value.get("url", "placeholder")
         _ = cls(name, value)
@@ -158,6 +161,9 @@ class CollectionValidator(StrictDictValidator, AddsVariablesMixin):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a generic collection
+        """
         if isinstance(value, dict):
             value["urls"] = value.get("urls", [{"url": "placeholder"}])
         _ = cls(name, value)

--- a/src/ytdl_sub/downloaders/generic/collection_validator.py
+++ b/src/ytdl_sub/downloaders/generic/collection_validator.py
@@ -156,6 +156,12 @@ class CollectionValidator(StrictDictValidator, AddsVariablesMixin):
 
     _required_keys = {"urls"}
 
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["urls"] = value.get("urls", [{"url": "placeholder"}])
+        _ = cls(name, value)
+
     def __init__(self, name, value):
         super().__init__(name, value)
         self._urls = self._validate_key(key="urls", validator=CollectionUrlListValidator)

--- a/src/ytdl_sub/downloaders/generic/collection_validator.py
+++ b/src/ytdl_sub/downloaders/generic/collection_validator.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -41,6 +42,12 @@ class CollectionThumbnailListValidator(ListValidator[CollectionThumbnailValidato
 class CollectionUrlValidator(StrictDictValidator):
     _required_keys = {"url"}
     _optional_keys = {"variables", "source_thumbnails", "playlist_thumbnails"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["url"] = value.get("url", "placeholder")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/downloaders/soundcloud/albums_and_singles.py
+++ b/src/ytdl_sub/downloaders/soundcloud/albums_and_singles.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import Generator
 
@@ -31,6 +32,15 @@ class SoundcloudAlbumsAndSinglesDownloadOptions(DownloaderValidator):
 
     _required_keys = {"url"}
     _optional_keys = {"skip_premiere_tracks"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a Soundcloud source
+        """
+        if isinstance(value, dict):
+            value["url"] = value.get("url", "https://soundcloud.com/jessebannon")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/downloaders/youtube/channel.py
+++ b/src/ytdl_sub/downloaders/youtube/channel.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -33,6 +34,14 @@ class YoutubeChannelDownloaderOptions(DownloaderValidator):
         "channel_avatar_path",
         "channel_banner_path",
     }
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["channel_url"] = value.get(
+                "channel_url", "https://www.youtube.com/c/ProjectZombie603"
+            )
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/downloaders/youtube/channel.py
+++ b/src/ytdl_sub/downloaders/youtube/channel.py
@@ -37,6 +37,9 @@ class YoutubeChannelDownloaderOptions(DownloaderValidator):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a YouTube channel source
+        """
         if isinstance(value, dict):
             value["channel_url"] = value.get(
                 "channel_url", "https://www.youtube.com/c/ProjectZombie603"

--- a/src/ytdl_sub/downloaders/youtube/playlist.py
+++ b/src/ytdl_sub/downloaders/youtube/playlist.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -30,6 +31,17 @@ class YoutubePlaylistDownloaderOptions(DownloaderValidator):
 
     _required_keys = {"playlist_url"}
     _optional_keys = {"playlist_thumbnail_name"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a YouTube playlist source
+        """
+        if isinstance(value, dict):
+            value["playlist_url"] = value.get(
+                "playlist_url", "https://www.youtube.com/playlist?list=UCsvn_Po0SmunchJYtttWpOxMg"
+            )
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/downloaders/youtube/video.py
+++ b/src/ytdl_sub/downloaders/youtube/video.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 
 from ytdl_sub.downloaders.downloader import Downloader
@@ -31,6 +32,15 @@ class YoutubeVideoDownloaderOptions(DownloaderValidator):
     """
 
     _required_keys = {"video_url"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate a YouTube video source
+        """
+        if isinstance(value, dict):
+            value["video_url"] = value.get("video_url", "youtube.com/watch?v=VMAPTo7RVDo")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/audio_extract.py
+++ b/src/ytdl_sub/plugins/audio_extract.py
@@ -1,4 +1,5 @@
 import os.path
+from typing import Any
 from typing import Dict
 from typing import Optional
 
@@ -27,7 +28,14 @@ class AudioExtractOptions(PluginOptions):
              quality: 128
     """
 
-    _optional_keys = {"codec", "quality"}
+    _required_keys = {"codec"}
+    _optional_keys = {"quality"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["codec"] = value.get("codec", "mp3")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/audio_extract.py
+++ b/src/ytdl_sub/plugins/audio_extract.py
@@ -33,6 +33,9 @@ class AudioExtractOptions(PluginOptions):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate audio extract options
+        """
         if isinstance(value, dict):
             value["codec"] = value.get("codec", "mp3")
         _ = cls(name, value)

--- a/src/ytdl_sub/plugins/file_convert.py
+++ b/src/ytdl_sub/plugins/file_convert.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 from typing import Dict
 from typing import Optional
 
@@ -26,6 +27,15 @@ class FileConvertOptions(PluginOptions):
     """
 
     _required_keys = {"convert_to"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate file_convert
+        """
+        if isinstance(value, dict):
+            value["convert_to"] = value.get("convert_to", "mp3")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/music_tags.py
+++ b/src/ytdl_sub/plugins/music_tags.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 
 import mediafile
@@ -33,6 +34,15 @@ class MusicTagsOptions(PluginOptions):
     """
 
     _required_keys = {"tags"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate music tags
+        """
+        if isinstance(value, dict):
+            value["tags"] = value.get("tags", {})
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/nfo_tags.py
+++ b/src/ytdl_sub/plugins/nfo_tags.py
@@ -2,6 +2,7 @@ import os
 from abc import ABC
 from collections import defaultdict
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -28,16 +29,21 @@ class SharedNfoTagsOptions(PluginOptions):
     _required_keys = {"nfo_name", "nfo_root", "tags"}
     _optional_keys = {"kodi_safe"}
 
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["nfo_name"] = value.get("nfo_name", "placeholder")
+            value["nfo_root"] = value.get("nfo_root", "placeholder")
+            value["tags"] = value.get("tags", {})
+
+        _ = cls(name=name, value=value)
+
     def __init__(self, name, value):
         super().__init__(name, value)
 
-        self._nfo_name = self._validate_key_if_present(
-            key="nfo_name", validator=StringFormatterValidator
-        )
-        self._nfo_root = self._validate_key_if_present(
-            key="nfo_root", validator=StringFormatterValidator
-        )
-        self._tags = self._validate_key_if_present(key="tags", validator=NfoTagsValidator)
+        self._nfo_name = self._validate_key(key="nfo_name", validator=StringFormatterValidator)
+        self._nfo_root = self._validate_key(key="nfo_root", validator=StringFormatterValidator)
+        self._tags = self._validate_key(key="tags", validator=NfoTagsValidator)
         self._kodi_safe = self._validate_key_if_present(
             key="kodi_safe", validator=BoolValidator, default=False
         ).value

--- a/src/ytdl_sub/plugins/nfo_tags.py
+++ b/src/ytdl_sub/plugins/nfo_tags.py
@@ -41,9 +41,13 @@ class SharedNfoTagsOptions(PluginOptions):
     def __init__(self, name, value):
         super().__init__(name, value)
 
-        self._nfo_name = self._validate_key(key="nfo_name", validator=StringFormatterValidator)
-        self._nfo_root = self._validate_key(key="nfo_root", validator=StringFormatterValidator)
-        self._tags = self._validate_key(key="tags", validator=NfoTagsValidator)
+        self._nfo_name = self._validate_key_if_present(
+            key="nfo_name", validator=StringFormatterValidator
+        )
+        self._nfo_root = self._validate_key_if_present(
+            key="nfo_root", validator=StringFormatterValidator
+        )
+        self._tags = self._validate_key_if_present(key="tags", validator=NfoTagsValidator)
         self._kodi_safe = self._validate_key_if_present(
             key="kodi_safe", validator=BoolValidator, default=False
         ).value

--- a/src/ytdl_sub/plugins/nfo_tags.py
+++ b/src/ytdl_sub/plugins/nfo_tags.py
@@ -31,6 +31,9 @@ class SharedNfoTagsOptions(PluginOptions):
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate NFO tag options
+        """
         if isinstance(value, dict):
             value["nfo_name"] = value.get("nfo_name", "placeholder")
             value["nfo_root"] = value.get("nfo_root", "placeholder")

--- a/src/ytdl_sub/plugins/regex.py
+++ b/src/ytdl_sub/plugins/regex.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -148,6 +149,15 @@ class RegexOptions(PluginOptions):
 
     _required_keys = {"from"}
     _optional_keys = {"skip_if_match_fails"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate regex
+        """
+        if isinstance(value, dict):
+            value["from"] = value.get("from", {})
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/split_by_chapters.py
+++ b/src/ytdl_sub/plugins/split_by_chapters.py
@@ -1,6 +1,7 @@
 import copy
 import os.path
 from pathlib import Path
+from typing import Any
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -66,6 +67,12 @@ class SplitByChaptersOptions(PluginOptions):
     """
 
     _required_keys = {"when_no_chapters"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        if isinstance(value, dict):
+            value["when_no_chapters"] = value.get("when_no_chapters", "pass")
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/plugins/video_tags.py
+++ b/src/ytdl_sub/plugins/video_tags.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 
 from ytdl_sub.entries.entry import Entry
@@ -26,6 +27,15 @@ class VideoTagsOptions(PluginOptions):
     """
 
     _required_keys = {"tags"}
+
+    @classmethod
+    def partial_validate(cls, name: str, value: Any) -> None:
+        """
+        Partially validate video tags
+        """
+        if isinstance(value, dict):
+            value["tags"] = value.get("tags", {})
+        _ = cls(name, value)
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/prebuilt_presets/__init__.py
+++ b/src/ytdl_sub/prebuilt_presets/__init__.py
@@ -1,6 +1,7 @@
 import pathlib
 from typing import Any
 from typing import Dict
+from typing import Set
 
 import mergedeep
 
@@ -21,3 +22,8 @@ def _merge_presets() -> Dict[str, Any]:
 
 
 PREBUILT_PRESETS: Dict[str, Any] = _merge_presets()
+
+PREBUILT_PRESET_NAMES: Set[str] = set(PREBUILT_PRESETS.keys())
+PUBLISHED_PRESET_NAMES: Set[str] = {
+    name for name in PREBUILT_PRESET_NAMES if not name.startswith("_")
+}

--- a/src/ytdl_sub/prebuilt_presets/music_videos/jellyfin-music-videos.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music_videos/jellyfin-music-videos.yaml
@@ -1,6 +1,0 @@
-presets:
-
-  kodi-music-videos:
-    preset:
-      - "jellyfin-music-videos"
-      - "kodi-safe"

--- a/src/ytdl_sub/prebuilt_presets/music_videos/kodi_music_videos.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music_videos/kodi_music_videos.yaml
@@ -3,7 +3,7 @@ presets:
   kodi_music_video:
     generic:
       download_strategy: "source"
-      music_video_url: "{music_video_url}"
+      url: "{music_video_url}"
 
     output_options:
       output_directory: "{music_video_directory}"

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
@@ -18,6 +18,7 @@ presets:
 
   collection_season_1:
     generic:
+      download_strategy: "collection"
       urls:
         - url: "{collection_season_1_url}"
           variables:
@@ -42,6 +43,7 @@ presets:
 
   collection_season_2:
     generic:
+      download_strategy: "collection"
       urls:
         - url: "{collection_season_2_url}"
           variables:
@@ -60,6 +62,7 @@ presets:
 
   collection_season_3:
     generic:
+      download_strategy: "collection"
       urls:
         - url: "{collection_season_3_url}"
           variables:
@@ -78,6 +81,7 @@ presets:
 
   collection_season_4:
     generic:
+      download_strategy: "collection"
       urls:
         - url: "{collection_season_4_url}"
           variables:
@@ -96,6 +100,7 @@ presets:
 
   collection_season_5:
     generic:
+      download_strategy: "collection"
       urls:
         - url: "{collection_season_5_url}"
           variables:

--- a/src/ytdl_sub/subscriptions/base_subscription.py
+++ b/src/ytdl_sub/subscriptions/base_subscription.py
@@ -2,7 +2,7 @@ from abc import ABC
 from pathlib import Path
 from typing import Type
 
-from ytdl_sub.config.config_file import ConfigOptions
+from ytdl_sub.config.config_validator import ConfigOptions
 from ytdl_sub.config.preset import Preset
 from ytdl_sub.config.preset import PresetPlugins
 from ytdl_sub.config.preset_options import OutputOptions

--- a/src/ytdl_sub/validators/nfo_validators.py
+++ b/src/ytdl_sub/validators/nfo_validators.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from collections import defaultdict
+from typing import Any
 from typing import Dict
 from typing import List
 

--- a/src/ytdl_sub/validators/nfo_validators.py
+++ b/src/ytdl_sub/validators/nfo_validators.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from collections import defaultdict
-from typing import Any
 from typing import Dict
 from typing import List
 

--- a/src/ytdl_sub/validators/strict_dict_validator.py
+++ b/src/ytdl_sub/validators/strict_dict_validator.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import List
 from typing import Set
 

--- a/src/ytdl_sub/validators/strict_dict_validator.py
+++ b/src/ytdl_sub/validators/strict_dict_validator.py
@@ -1,4 +1,3 @@
-from typing import Any
 from typing import List
 from typing import Set
 

--- a/tests/unit/cli/test_download_args_parser.py
+++ b/tests/unit/cli/test_download_args_parser.py
@@ -9,7 +9,7 @@ import pytest
 from ytdl_sub.cli.download_args_parser import DownloadArgsParser
 from ytdl_sub.cli.main_args_parser import MainArgs
 from ytdl_sub.cli.main_args_parser import parser
-from ytdl_sub.config.config_file import ConfigOptions
+from ytdl_sub.config.config_validator import ConfigOptions
 from ytdl_sub.utils.exceptions import InvalidDlArguments
 
 

--- a/tests/unit/config/test_config_file.py
+++ b/tests/unit/config/test_config_file.py
@@ -37,7 +37,7 @@ class TestConfigFilePartiallyValidatesPresets:
             {"nfo_tags": {"tags": {"key-1": "preset_0"}}},
             {"output_directory_nfo_tags": {"nfo_root": "test"}},
             {"output_options": {"file_name": "test"}},
-            {"output_options": {"keep_files_after": "today", "maintain_download_archive": True}},
+            {"output_options": {"keep_files_after": "today"}},
             {"ytdl_options": {"format": "best"}},
             {"overrides": {"a": "b"}},
         ],

--- a/tests/unit/config/test_config_file.py
+++ b/tests/unit/config/test_config_file.py
@@ -1,0 +1,131 @@
+import re
+from typing import Dict
+from typing import Optional
+
+import pytest
+
+from ytdl_sub.config.config_file import ConfigFile
+from ytdl_sub.config.preset import PRESET_KEYS
+from ytdl_sub.config.preset_class_mappings import PluginMapping
+from ytdl_sub.utils.exceptions import ValidationException
+
+
+class TestConfigFilePartiallyValidatesPresets:
+    @classmethod
+    def _partial_validate(
+        cls, preset_dict: Dict, expected_error_message: Optional[str] = None
+    ) -> None:
+        def _config_create() -> None:
+            _ = ConfigFile(
+                name="test_partial_validate",
+                value={
+                    "configuration": {"working_directory": "."},
+                    "presets": {"partial_preset": preset_dict},
+                },
+            )
+
+        if expected_error_message:
+            with pytest.raises(ValidationException, match=re.escape(expected_error_message)):
+                _config_create()
+        else:
+            _config_create()
+
+    @pytest.mark.parametrize(
+        "preset_dict",
+        [
+            {"nfo_tags": {"tags": {"key-1": "preset_0"}}},
+            {"output_directory_nfo_tags": {"nfo_root": "test"}},
+            {"output_options": {"file_name": "test"}},
+            {"output_options": {"keep_files_after": "today", "maintain_download_archive": True}},
+            {"ytdl_options": {"format": "best"}},
+            {"overrides": {"a": "b"}},
+        ],
+    )
+    def test_success(self, preset_dict: Dict):
+        self._partial_validate(preset_dict)
+
+    @pytest.mark.parametrize("plugin", PluginMapping.plugins())
+    def test_success__empty_plugins(self, plugin: str):
+        self._partial_validate({plugin: {}})
+
+    def test_error__bad_preset_section(self):
+        self._partial_validate(
+            preset_dict={"does_not_exist": "lol"},
+            expected_error_message="Validation error in partial_preset: "
+            "'partial_preset' contains the field 'does_not_exist' which is not allowed. "
+            f"Allowed fields: {', '.join(sorted(PRESET_KEYS))}",
+        )
+
+    def test_error__multiple_sources(self):
+        self._partial_validate(
+            preset_dict={"youtube": {}, "generic": {}},
+            expected_error_message="Validation error in partial_preset: "
+            "Contains the sources generic, youtube but can only have one",
+        )
+
+    def test_error__no_download_strategy(self):
+        self._partial_validate(
+            preset_dict={"generic": {}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "missing the required field 'download_strategy'",
+        )
+
+    def test_error__bad_download_strategy(self):
+        self._partial_validate(
+            preset_dict={"generic": {"download_strategy": "fail"}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "Tried to use download strategy 'fail' with source 'generic', "
+            "which does not exist. Available download strategies: collection, source",
+        )
+
+    def test_error__bad_download_strategy_args(self):
+        self._partial_validate(
+            preset_dict={"generic": {"download_strategy": "collection", "bad_key": "nope"}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "'partial_preset.generic' contains the field 'bad_key' which is not allowed. "
+            "Allowed fields: urls",
+        )
+
+    @pytest.mark.parametrize(
+        "preset_dict",
+        [
+            {"nfo_tags": {"tags": {"key-1": {"attributes": {"test": "2"}}}}},
+            {"generic": {"urls": [{"variables_to_set": {"name": "value"}}]}},
+        ],
+    )
+    def test_partial_validate__incomplete_list_item(self, preset_dict):
+        with pytest.raises(ValidationException):
+            _ = ConfigFile(
+                name="test_partial_validate",
+                value={
+                    "configuration": {"working_directory": "."},
+                    "presets": {"partial_preset": preset_dict},
+                },
+            )
+
+    @pytest.mark.parametrize(
+        "preset_dict",
+        [
+            {"overrides": "not a dict"},
+            {"overrides": {"nested": {"dict": "value"}}},
+            {"overrides": ["list"]},
+        ],
+    )
+    def test_error__bad_overrides(self, preset_dict):
+        self._partial_validate(
+            preset_dict=preset_dict,
+            expected_error_message="Validation error in partial_preset.overrides",
+        )
+
+    @pytest.mark.parametrize(
+        "preset_dict",
+        [
+            {"ytdl_options": "not a dict"},
+            {"ytdl_options": ["list"]},
+        ],
+    )
+    def test_error__bad_ytdl_options(self, preset_dict):
+        self._partial_validate(
+            preset_dict=preset_dict,
+            expected_error_message="Validation error in partial_preset.ytdl_options",
+        )

--- a/tests/unit/config/test_preset.py
+++ b/tests/unit/config/test_preset.py
@@ -1,8 +1,11 @@
+import re
 from typing import Dict
+from typing import Optional
 
 import pytest
 
 from ytdl_sub.config.config_file import ConfigFile
+from ytdl_sub.config.preset import PRESET_KEYS
 from ytdl_sub.config.preset import Preset
 from ytdl_sub.plugins.nfo_tags import NfoTagsOptions
 from ytdl_sub.utils.exceptions import StringFormattingVariableNotFoundException
@@ -103,7 +106,7 @@ class TestPreset:
                 "youtube": youtube_video,
                 "output_options": dict(
                     output_options,
-                    **{"maintain_download_archive": True, "keep_files_after": "today-{ttl}"}
+                    **{"maintain_download_archive": True, "keep_files_after": "today-{ttl}"},
                 ),
                 "overrides": {"ttl": "2months"},
             },
@@ -206,6 +209,25 @@ class TestPreset:
 
 
 class TestPresetPartialValidate:
+    @classmethod
+    def _partial_validate(
+        cls, preset_dict: Dict, expected_error_message: Optional[str] = None
+    ) -> None:
+        def _config_create() -> None:
+            _ = ConfigFile(
+                name="test_partial_validate",
+                value={
+                    "configuration": {"working_directory": "."},
+                    "presets": {"partial_preset": preset_dict},
+                },
+            )
+
+        if expected_error_message:
+            with pytest.raises(ValidationException, match=re.escape(expected_error_message)):
+                _config_create()
+        else:
+            _config_create()
+
     @pytest.mark.parametrize(
         "preset_dict",
         [
@@ -216,33 +238,48 @@ class TestPresetPartialValidate:
             {"ytdl_options": {"format": "best"}},
         ],
     )
-    def test_partial_validate(self, preset_dict):
-        _ = ConfigFile(
-            name="test_partial_validate",
-            value={
-                "configuration": {"working_directory": "."},
-                "presets": {"partial_preset": preset_dict},
-            },
+    def test_success(self, preset_dict: Dict):
+        self._partial_validate(
+            preset_dict,
         )
 
-    @pytest.mark.parametrize(
-        "preset_dict",
-        [
-            {"youtube": {}, "generic": {}},  # multiple sources
-            {"generic": {}},  # no download strategy
-            {"generic": {"download_strategy": "fail"}},  # bad download strategy
-            {"generic": {"download_strategy": "collection", "bad_key": "nope"}}  # bad strategy args
-        ],
-    )
-    def test_partial_validate__bad_sources(self, preset_dict):
-        with pytest.raises(ValidationException):
-            _ = ConfigFile(
-                name="test_partial_validate",
-                value={
-                    "configuration": {"working_directory": "."},
-                    "presets": {"partial_preset": preset_dict},
-                },
-            )
+    def test_error__bad_preset_section(self):
+        self._partial_validate(
+            preset_dict={"does_not_exist": "lol"},
+            expected_error_message="Validation error in partial_preset: "
+            "'partial_preset' contains the field 'does_not_exist' which is not allowed. "
+            f"Allowed fields: {', '.join(sorted(PRESET_KEYS))}",
+        )
+
+    def test_error__multiple_sources(self):
+        self._partial_validate(
+            preset_dict={"youtube": {}, "generic": {}},
+            expected_error_message="Validation error in partial_preset: "
+            "Contains the sources generic, youtube but can only have one",
+        )
+
+    def test_error__no_download_strategy(self):
+        self._partial_validate(
+            preset_dict={"generic": {}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "missing the required field 'download_strategy'",
+        )
+
+    def test_error__bad_download_strategy(self):
+        self._partial_validate(
+            preset_dict={"generic": {"download_strategy": "fail"}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "Tried to use download strategy 'fail' with source 'generic', "
+            "which does not exist. Available download strategies: collection, source",
+        )
+
+    def test_error__bad_download_strategy_args(self):
+        self._partial_validate(
+            preset_dict={"generic": {"download_strategy": "collection", "bad_key": "nope"}},
+            expected_error_message="Validation error in partial_preset.generic: "
+            "'partial_preset.generic' contains the field 'bad_key' which is not allowed. "
+            "Allowed fields: urls",
+        )
 
     @pytest.mark.parametrize(
         "preset_dict",

--- a/tests/unit/config/test_preset.py
+++ b/tests/unit/config/test_preset.py
@@ -202,3 +202,7 @@ class TestPreset:
                     },
                 },
             )
+
+    def test_partial_validate(self, config_file):
+        for preset_name, preset_dict in config_file.presets.dict.items():
+            Preset.preset_partial_validate(config_file, preset_name, preset_dict)

--- a/tests/unit/config/test_preset.py
+++ b/tests/unit/config/test_preset.py
@@ -1,11 +1,5 @@
-import re
-from typing import Dict
-from typing import Optional
-
 import pytest
 
-from ytdl_sub.config.config_file import ConfigFile
-from ytdl_sub.config.preset import PRESET_KEYS
 from ytdl_sub.config.preset import Preset
 from ytdl_sub.plugins.nfo_tags import NfoTagsOptions
 from ytdl_sub.utils.exceptions import StringFormattingVariableNotFoundException
@@ -204,96 +198,5 @@ class TestPreset:
                         "nfo_root": "the root",
                         "tags": {"tag_a": "{dne_var}"},
                     },
-                },
-            )
-
-
-class TestPresetPartialValidate:
-    @classmethod
-    def _partial_validate(
-        cls, preset_dict: Dict, expected_error_message: Optional[str] = None
-    ) -> None:
-        def _config_create() -> None:
-            _ = ConfigFile(
-                name="test_partial_validate",
-                value={
-                    "configuration": {"working_directory": "."},
-                    "presets": {"partial_preset": preset_dict},
-                },
-            )
-
-        if expected_error_message:
-            with pytest.raises(ValidationException, match=re.escape(expected_error_message)):
-                _config_create()
-        else:
-            _config_create()
-
-    @pytest.mark.parametrize(
-        "preset_dict",
-        [
-            {"nfo_tags": {"tags": {"key-1": "preset_0"}}},
-            {"output_directory_nfo_tags": {"nfo_root": "test"}},
-            {"output_directory": {"file_name": "test"}},
-            {"output_directory": {"keep_files_after": "today"}},
-            {"ytdl_options": {"format": "best"}},
-        ],
-    )
-    def test_success(self, preset_dict: Dict):
-        self._partial_validate(
-            preset_dict,
-        )
-
-    def test_error__bad_preset_section(self):
-        self._partial_validate(
-            preset_dict={"does_not_exist": "lol"},
-            expected_error_message="Validation error in partial_preset: "
-            "'partial_preset' contains the field 'does_not_exist' which is not allowed. "
-            f"Allowed fields: {', '.join(sorted(PRESET_KEYS))}",
-        )
-
-    def test_error__multiple_sources(self):
-        self._partial_validate(
-            preset_dict={"youtube": {}, "generic": {}},
-            expected_error_message="Validation error in partial_preset: "
-            "Contains the sources generic, youtube but can only have one",
-        )
-
-    def test_error__no_download_strategy(self):
-        self._partial_validate(
-            preset_dict={"generic": {}},
-            expected_error_message="Validation error in partial_preset.generic: "
-            "missing the required field 'download_strategy'",
-        )
-
-    def test_error__bad_download_strategy(self):
-        self._partial_validate(
-            preset_dict={"generic": {"download_strategy": "fail"}},
-            expected_error_message="Validation error in partial_preset.generic: "
-            "Tried to use download strategy 'fail' with source 'generic', "
-            "which does not exist. Available download strategies: collection, source",
-        )
-
-    def test_error__bad_download_strategy_args(self):
-        self._partial_validate(
-            preset_dict={"generic": {"download_strategy": "collection", "bad_key": "nope"}},
-            expected_error_message="Validation error in partial_preset.generic: "
-            "'partial_preset.generic' contains the field 'bad_key' which is not allowed. "
-            "Allowed fields: urls",
-        )
-
-    @pytest.mark.parametrize(
-        "preset_dict",
-        [
-            {"nfo_tags": {"tags": {"key-1": {"attributes": {"test": "2"}}}}},
-            {"generic": {"urls": [{"variables_to_set": {"name": "value"}}]}},
-        ],
-    )
-    def test_partial_validate__incomplete_list_item(self, preset_dict):
-        with pytest.raises(ValidationException):
-            _ = ConfigFile(
-                name="test_partial_validate",
-                value={
-                    "configuration": {"working_directory": "."},
-                    "presets": {"partial_preset": preset_dict},
                 },
             )

--- a/tests/unit/config/test_preset.py
+++ b/tests/unit/config/test_preset.py
@@ -229,6 +229,9 @@ class TestPresetPartialValidate:
         "preset_dict",
         [
             {"youtube": {}, "generic": {}},  # multiple sources
+            {"generic": {}},  # no download strategy
+            {"generic": {"download_strategy": "fail"}},  # bad download strategy
+            {"generic": {"download_strategy": "collection", "bad_key": "nope"}}  # bad strategy args
         ],
     )
     def test_partial_validate__bad_sources(self, preset_dict):
@@ -245,7 +248,7 @@ class TestPresetPartialValidate:
         "preset_dict",
         [
             {"nfo_tags": {"tags": {"key-1": {"attributes": {"test": "2"}}}}},
-            {"generic": {"urls": {"variables_to_set": {"name": "value"}}}},
+            {"generic": {"urls": [{"variables_to_set": {"name": "value"}}]}},
         ],
     )
     def test_partial_validate__incomplete_list_item(self, preset_dict):


### PR DESCRIPTION
https://github.com/jmbannon/ytdl-sub/issues/299
If a preset was not used in a config file, absolutely no validation was performed on it. This can give users the idea that it's valid when it's not. This change will now perform 'lightweight' validation for each preset in the config.

For existing ytdl-sub users, you may now get a validation error with valid presets in this scenario:
- specify a source with no download strategy

Just add the respective download strategy and you should be good to go.