### PR TITLE
Always perform copy/delete on OSError

### DIFF
--- a/src/ytdl_sub/utils/file_handler.py
+++ b/src/ytdl_sub/utils/file_handler.py
@@ -361,7 +361,7 @@ class FileHandler:
         """
         try:
             shutil.move(src=src_file_path, dst=dst_file_path)
-        except OSError as os_error_exc:
+        except OSError:
             # Invalid cross-device link
             # Can happen from using os.rename under the hood, which requires the two file on the
             # same filesystem. Work around it by copying and deleting the file

--- a/src/ytdl_sub/utils/file_handler.py
+++ b/src/ytdl_sub/utils/file_handler.py
@@ -365,11 +365,8 @@ class FileHandler:
             # Invalid cross-device link
             # Can happen from using os.rename under the hood, which requires the two file on the
             # same filesystem. Work around it by copying and deleting the file
-            if os_error_exc.errno == 18:
-                cls.copy(src_file_path, dst_file_path)
-                cls.delete(src_file_path)
-            else:
-                raise
+            cls.copy(src_file_path, dst_file_path)
+            cls.delete(src_file_path)
 
     @classmethod
     def delete(cls, file_path: Union[str, Path]):


### PR DESCRIPTION
Extends the fix in #400 to handle all potential OSError errno values and attempt a copy/delete in all cases. For example, a combination cross-device move and a permissions change would throw errno 1 instead of errno 18, which wasn't caught here. Instead of messing with individual errno numbers, just always attempt a copy/delete and let those throw their own exceptions if they don't work either.