### PR TITLE
Fix yaml syntax for initial docker-compose setup

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -37,7 +37,7 @@ on how set up a cron job in the docker container.
          - <path/to/movies>:/movies # optional
          - <path/to/music_videos>:/music_videos # optional
          - <path/to/music>:/music # optional
-      restart: unless-stopped
+       restart: unless-stopped
 
 Docker
 --------------


### PR DESCRIPTION
The provided `docker-compose.yml` config is not valid YAML, due to a missing space in the last line.