### PR TITLE
[BUGFIX] Fix Windows split by chapters not reading chapter titles correctly

### DIFF
--- a/src/ytdl_sub/plugins/split_by_chapters.py
+++ b/src/ytdl_sub/plugins/split_by_chapters.py
@@ -164,14 +164,7 @@ class SplitByChaptersPlugin(Plugin[SplitByChaptersOptions]):
         Tags the entry's audio file using values defined in the metadata options
         """
         split_videos_and_metadata: List[Tuple[Entry, FileMetadata]] = []
-
-        if self.is_dry_run:
-            chapters = Chapters.from_entry_chapters(entry=entry)
-        else:
-            chapters = Chapters.from_embedded_chapters(
-                ffprobe_path=FFMPEG.ffprobe_path(),
-                file_path=entry.get_download_file_path(),
-            )
+        chapters = Chapters.from_entry_chapters(entry=entry)
 
         # If no chapters, do not split anything
         if not chapters.contains_any_chapters():

--- a/src/ytdl_sub/utils/chapters.py
+++ b/src/ytdl_sub/utils/chapters.py
@@ -1,13 +1,12 @@
-import json
 import re
-import subprocess
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
 
 from ytdl_sub.entries.entry import Entry
-from ytdl_sub.entries.variables.kwargs import YTDL_SUB_CUSTOM_CHAPTERS, CHAPTERS
+from ytdl_sub.entries.variables.kwargs import CHAPTERS
+from ytdl_sub.entries.variables.kwargs import YTDL_SUB_CUSTOM_CHAPTERS
 from ytdl_sub.utils.file_handler import FileMetadata
 
 
@@ -237,7 +236,9 @@ class Chapters:
         titles: List[str] = []
 
         # Try to get actual yt-dlp chapters first, then custom chapters, then default to empty list
-        chapters = entry.kwargs_get(CHAPTERS, default=entry.kwargs_get(YTDL_SUB_CUSTOM_CHAPTERS, default=[]))
+        chapters = entry.kwargs_get(
+            CHAPTERS, default=entry.kwargs_get(YTDL_SUB_CUSTOM_CHAPTERS, default=[])
+        )
 
         for chapter in chapters:
             timestamps.append(Timestamp.from_seconds(int(float(chapter["start_time"]))))

--- a/src/ytdl_sub/utils/chapters.py
+++ b/src/ytdl_sub/utils/chapters.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Tuple
 
 from ytdl_sub.entries.entry import Entry
+from ytdl_sub.entries.variables.kwargs import YTDL_SUB_CUSTOM_CHAPTERS, CHAPTERS
 from ytdl_sub.utils.file_handler import FileMetadata
 
 
@@ -221,45 +222,6 @@ class Chapters:
         return Chapters(timestamps=timestamps, titles=titles)
 
     @classmethod
-    def from_embedded_chapters(cls, ffprobe_path: str, file_path: str) -> "Chapters":
-        """
-        Parameters
-        ----------
-        ffprobe_path
-            Path to ffprobe executable
-        file_path
-            File to read ffmpeg chapter metadata from
-
-        Returns
-        -------
-        Chapters object
-        """
-        proc = subprocess.run(
-            [
-                ffprobe_path,
-                "-loglevel",
-                "quiet",
-                "-print_format",
-                "json",
-                "-show_chapters",
-                "--",
-                file_path,
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
-        )
-
-        embedded_chapters = json.loads(proc.stdout)
-        timestamps: List[Timestamp] = []
-        titles: List[str] = []
-        for chapter in embedded_chapters["chapters"]:
-            timestamps.append(Timestamp.from_seconds(int(float(chapter["start_time"]))))
-            titles.append(chapter["tags"]["title"])
-
-        return Chapters(timestamps=timestamps, titles=titles)
-
-    @classmethod
     def from_entry_chapters(cls, entry: Entry) -> "Chapters":
         """
         Parameters
@@ -274,9 +236,8 @@ class Chapters:
         timestamps: List[Timestamp] = []
         titles: List[str] = []
 
-        chapters = {}
-        if entry.kwargs_contains("chapters"):
-            chapters = entry.kwargs("chapters") or []
+        # Try to get actual yt-dlp chapters first, then custom chapters, then default to empty list
+        chapters = entry.kwargs_get(CHAPTERS, default=entry.kwargs_get(YTDL_SUB_CUSTOM_CHAPTERS, default=[]))
 
         for chapter in chapters:
             timestamps.append(Timestamp.from_seconds(int(float(chapter["start_time"]))))


### PR DESCRIPTION
Use yt-dlp's chapter metadata instead of relying on ffprobe