### PR TITLE
Fix --update-with-info-json message

### DIFF
--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -316,8 +316,9 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
                 and not config.config_options.experimental.enable_update_with_info_json
             ):
                 raise ExperimentalFeatureNotEnabled(
-                    "--update-with-info-json requires setting "
-                    "configuration.experimental.enable_update_with_info_json to True. This feature is ",
+                    "--update-with-info-json requires setting"
+                    " configuration.experimental.enable_update_with_info_json to True. This"
+                    " feature is ",
                     "still being tested and has the ability to destroy files. Ensure you have a ",
                     "full backup before usage. You have been warned!",
                 )

--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -317,7 +317,7 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
             ):
                 raise ExperimentalFeatureNotEnabled(
                     "--update-with-info-json requires setting "
-                    "configuration.experimental.update_with_info_json to True. This feature is ",
+                    "configuration.experimental.enable_update_with_info_json to True. This feature is ",
                     "still being tested and has the ability to destroy files. Ensure you have a ",
                     "full backup before usage. You have been warned!",
                 )


### PR DESCRIPTION
Didn't realize why the configuration option wasn't working at first, then I realized the warning printed the wrong option.