### PR TITLE
[BUGFIX] Fix date_range plugin as a match-filter

### DIFF
--- a/src/ytdl_sub/plugins/date_range.py
+++ b/src/ytdl_sub/plugins/date_range.py
@@ -2,6 +2,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from yt_dlp.utils import datetime_from_str
+
 from ytdl_sub.config.plugin import Plugin
 from ytdl_sub.config.preset_options import OptionsDictValidator
 from ytdl_sub.validators.string_datetime import StringDatetimeValidator
@@ -47,6 +49,10 @@ class DateRangeOptions(OptionsDictValidator):
 class DateRangePlugin(Plugin[DateRangeOptions]):
     plugin_options_type = DateRangeOptions
 
+    def _to_date(self, date_validator: StringDatetimeValidator) -> str:
+        date_str = self.overrides.apply_formatter(formatter=date_validator)
+        return str(datetime_from_str(date_str).date())
+
     def ytdl_options_match_filters(self) -> Tuple[List[str], List[str]]:
         """
         Returns
@@ -57,11 +63,11 @@ class DateRangePlugin(Plugin[DateRangeOptions]):
         breaking_match_filters: List[str] = []
 
         if self.plugin_options.before:
-            before_str = self.overrides.apply_formatter(formatter=self.plugin_options.before)
-            match_filters.append(f"upload_date < {before_str}")
+            match_filters.append(f"upload_date < {self._to_date(self.plugin_options.before)}")
 
         if self.plugin_options.after:
-            after_str = self.overrides.apply_formatter(formatter=self.plugin_options.after)
-            breaking_match_filters.append(f"upload_date >= {after_str}")
+            breaking_match_filters.append(
+                f"upload_date >= {self._to_date(self.plugin_options.after)}"
+            )
 
         return match_filters, breaking_match_filters

--- a/src/ytdl_sub/plugins/date_range.py
+++ b/src/ytdl_sub/plugins/date_range.py
@@ -2,10 +2,9 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from yt_dlp.utils import datetime_from_str
-
 from ytdl_sub.config.plugin import Plugin
 from ytdl_sub.config.preset_options import OptionsDictValidator
+from ytdl_sub.utils.datetime import to_date_str
 from ytdl_sub.validators.string_datetime import StringDatetimeValidator
 
 
@@ -49,10 +48,6 @@ class DateRangeOptions(OptionsDictValidator):
 class DateRangePlugin(Plugin[DateRangeOptions]):
     plugin_options_type = DateRangeOptions
 
-    def _to_date(self, date_validator: StringDatetimeValidator) -> str:
-        date_str = self.overrides.apply_formatter(formatter=date_validator)
-        return str(datetime_from_str(date_str).date())
-
     def ytdl_options_match_filters(self) -> Tuple[List[str], List[str]]:
         """
         Returns
@@ -63,11 +58,15 @@ class DateRangePlugin(Plugin[DateRangeOptions]):
         breaking_match_filters: List[str] = []
 
         if self.plugin_options.before:
-            match_filters.append(f"upload_date < {self._to_date(self.plugin_options.before)}")
+            before_str = to_date_str(
+                date_validator=self.plugin_options.before, overrides=self.overrides
+            )
+            match_filters.append(f"upload_date < {before_str}")
 
         if self.plugin_options.after:
-            breaking_match_filters.append(
-                f"upload_date >= {self._to_date(self.plugin_options.after)}"
+            after_str = to_date_str(
+                date_validator=self.plugin_options.after, overrides=self.overrides
             )
+            breaking_match_filters.append(f"upload_date >= {after_str}")
 
         return match_filters, breaking_match_filters

--- a/src/ytdl_sub/utils/datetime.py
+++ b/src/ytdl_sub/utils/datetime.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from yt_dlp import DateRange
+from yt_dlp.utils import datetime_from_str
 
 from ytdl_sub.config.preset_options import Overrides
 from ytdl_sub.validators.string_datetime import StringDatetimeValidator
@@ -29,3 +30,13 @@ def to_date_range(
         return DateRange(start=start, end=end)
 
     return None
+
+
+def to_date_str(date_validator: StringDatetimeValidator, overrides: Overrides) -> str:
+    """
+    Returns
+    -------
+    Date in the form of YYYYMMDD as a string
+    """
+    date_str = overrides.apply_formatter(formatter=date_validator)
+    return datetime_from_str(date_str).date().strftime("%Y%m%d")


### PR DESCRIPTION
Convert yt-dlp date formats (i.e. `today-2months`) into a date string with format `YYYYMMDD`