### PR TITLE
[BACKEND] Add `!is_live` match-filter by default to TV show presets

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/helpers/players.yaml
+++ b/src/ytdl_sub/prebuilt_presets/helpers/players.yaml
@@ -1,6 +1,9 @@
 presets:
 
   _base:
+    match_filters:
+      filters:
+        - "!is_live"
     overrides:
       file_uid: "{uid_sanitized}"
       file_title: "{title_sanitized}"


### PR DESCRIPTION
https://github.com/jmbannon/ytdl-sub/issues/729