### PR TITLE
[FEATURE] Ability to add subscription value via config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -2,7 +2,7 @@ Config
 ======
 ytdl-sub is configured using a ``config.yaml`` file.
 
-.. _config_yaml:
+.. _config:
 
 config.yaml
 -----------
@@ -318,8 +318,10 @@ by using the file-wide ``__preset__``:
 This ``subscription.yaml`` is equivalent to the one above it because all
 subscriptions automatically set ``__preset__`` as a `parent preset`_.
 
-File Subscription Value
-^^^^^^^^^^^^^^^^^^^^^^^
+.. _subscription value:
+
+Subscription Value
+^^^^^^^^^^^^^^^^^^^
 With a clever config and use of ``__preset__``, your subscriptions can typically boil
 down to a name and url. You can set ``__value__`` to the name of an override variable,
 and use the override variable ``subscription_name`` to achieve one-liner subscriptions.
@@ -329,20 +331,19 @@ Using the example above, we can do:
   :caption: subscription.yaml
 
    __preset__:
-     preset: "playlist_preset_ex"
+     preset:
+       - "tv_show"
      overrides:
-       playlist_name: "{subscription_name}"
+       tv_show_name: "{subscription_name}"
 
    __value__: "url"
 
-   # single-line subscription
-   "diy-playlist": "https://youtube.com/playlist?list=UCsvn_Po0SmunchJYtttWpOxMg"
-
-``"diy-playlist"`` gets assigned to the ``playlist_name`` override variable by setting
-it with ``subscription_name`` , and the url gets assigned to ``url`` by setting ``__value__``
-to write values to it.
+   # single-line subscription, sets "Brandon Acker" and the subscription value
+   # to the override variables tv_show_name and url
+   "Brandon Acker": "https://www.youtube.com/@brandonacker"
 
 Traditional subscriptions that can override presets will still work when using ``__value__``.
+``__value__`` can also be set within a :ref:`config`.
 
 -------------------------------------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ ytdl-sub configs, check out the
 
 
 For navigating config docs, use the left-side bar on the
-:ref:`config_yaml` page to find every available ytdl-sub field.
+:ref:`config` page to find every available ytdl-sub field.
 
 Contents
 ========

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -106,6 +106,7 @@ class ConfigOptions(StrictDictValidator):
         "ffprobe_path",
         "file_name_max_bytes",
         "experimental",
+        "subscription_value",
     }
 
     def __init__(self, name: str, value: Any):
@@ -137,6 +138,9 @@ class ConfigOptions(StrictDictValidator):
         )
         self._file_name_max_bytes = self._validate_key(
             key="file_name_max_bytes", validator=IntValidator, default=MAX_FILE_NAME_BYTES
+        )
+        self._subscription_value = self._validate_key_if_present(
+            key="subscription_value", validator=StringValidator
         )
 
     @property
@@ -229,6 +233,14 @@ class ConfigOptions(StrictDictValidator):
         ``ffprobe.exe`` for Windows (in the same directory as ytdl-sub).
         """
         return self._ffprobe_path.value
+
+    @property
+    def subscription_value(self) -> Optional[str]:
+        """
+        Optional. Sets the (TODO: LINK)
+        subscription value key for subscription files that use this config.
+        """
+        return self._subscription_value.value if self._subscription_value else None
 
 
 class ConfigValidator(StrictDictValidator):

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -237,8 +237,8 @@ class ConfigOptions(StrictDictValidator):
     @property
     def subscription_value(self) -> Optional[str]:
         """
-        Optional. Sets the (TODO: LINK)
-        subscription value key for subscription files that use this config.
+        Optional. Sets the :ref:`subscription value` for subscription
+        files that use this config.
         """
         return self._subscription_value.value if self._subscription_value else None
 

--- a/src/ytdl_sub/subscriptions/subscription.py
+++ b/src/ytdl_sub/subscriptions/subscription.py
@@ -65,7 +65,9 @@ class Subscription(SubscriptionDownload):
         )
 
     @classmethod
-    def _maybe_get_subscription_value(cls, config: ConfigFile, subscription_dict: Dict) -> Optional[str]:
+    def _maybe_get_subscription_value(
+        cls, config: ConfigFile, subscription_dict: Dict
+    ) -> Optional[str]:
         if FILE_SUBSCRIPTION_VALUE_KEY in subscription_dict:
             if not isinstance(subscription_dict[FILE_SUBSCRIPTION_VALUE_KEY], str):
                 raise ValidationException(

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -30,28 +30,26 @@ def mock_load_yaml(preset_dict: Dict) -> None:
 
 
 @pytest.fixture
-def preset_file(youtube_video: Dict, output_options: Dict):
-    with patch("ytdl_sub.subscriptions.subscription.load_yaml") as mock_load_yaml:
-        mock_load_yaml.return_value = {
-            "__preset__": {
-                "download": youtube_video,
-                "output_options": output_options,
-                "nfo_tags": {
-                    "tags": {"key-3": "file_preset"},
-                },
-                "overrides": {
-                    "test_file_subscription_value": "original",
-                    "test_config_subscription_value": "original",
-                },
+def preset_with_file_preset(youtube_video: Dict, output_options: Dict):
+    return {
+        "__preset__": {
+            "download": youtube_video,
+            "output_options": output_options,
+            "nfo_tags": {
+                "tags": {"key-3": "file_preset"},
             },
-            "test_preset": {
-                "preset": "parent_preset_3",
-                "nfo_tags": {
-                    "tags": {"key-4": "test_preset"},
-                },
+            "overrides": {
+                "test_file_subscription_value": "original",
+                "test_config_subscription_value": "original",
             },
-        }
-        yield
+        },
+        "test_preset": {
+            "preset": "parent_preset_3",
+            "nfo_tags": {
+                "tags": {"key-4": "test_preset"},
+            },
+        },
+    }
 
 
 @pytest.fixture
@@ -98,9 +96,9 @@ def preset_file_with_value(youtube_video: Dict, output_options: Dict):
         yield
 
 
-@pytest.mark.usefixtures(preset_file.__name__)
-def test_subscription_file_preset_applies(config_file: ConfigFile):
-    subs = Subscription.from_file_path(config=config_file, subscription_path="mocked")
+def test_subscription_file_preset_applies(config_file: ConfigFile, preset_with_file_preset: Dict):
+    with mock_load_yaml(preset_dict=preset_with_file_preset):
+        subs = Subscription.from_file_path(config=config_file, subscription_path="mocked")
     assert len(subs) == 1
 
     # Test __preset__ worked correctly

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -147,7 +147,7 @@ def test_subscription_file_value_applies_from_config(
         )
     assert len(subs) == 2
 
-    # Test __value__ worked correctly
+    # Test __value__ worked correctly from the config
     value_sub = subs[1]
     assert value_sub.name == "test_value"
     assert (

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -124,7 +124,7 @@ def test_subscription_file_using_value_when_not_defined(config_file: ConfigFile)
         ValidationException,
         match=re.escape(
             f"Subscription sub_name is a string, but "
-            f"{FILE_SUBSCRIPTION_VALUE_KEY} is not set to an override variable"
+            f"the subscription value is not set to an override variable"
         ),
     ):
         _ = Subscription.from_file_path(config=config_file, subscription_path="mocked")


### PR DESCRIPTION
`Subscription Values` are how you can achieve one-liner subscriptions. This feature allows you to set it within the config. In the near future, ytdl-sub will strive to make subscription files simpler by hiding most of the "under-the-hood" logic within the config file.