### PR TITLE
[FEATURE] No longer require a config.yaml

### DIFF
--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -11,7 +11,8 @@ from colorama import Fore
 from yt_dlp.utils import sanitize_filename
 
 from ytdl_sub.cli.download_args_parser import DownloadArgsParser
-from ytdl_sub.cli.main_args_parser import parser, DEFAULT_CONFIG_FILE_NAME
+from ytdl_sub.cli.main_args_parser import DEFAULT_CONFIG_FILE_NAME
+from ytdl_sub.cli.main_args_parser import parser
 from ytdl_sub.config.config_file import ConfigFile
 from ytdl_sub.subscriptions.subscription import Subscription
 from ytdl_sub.utils.exceptions import ExperimentalFeatureNotEnabled
@@ -309,7 +310,7 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
     elif os.path.isfile(DEFAULT_CONFIG_FILE_NAME):
         config = ConfigFile.from_file_path(DEFAULT_CONFIG_FILE_NAME)
     else:
-        logger.debug("No config specified, using defaults")
+        logger.info("No config specified, using defaults")
 
     transaction_logs: List[Tuple[Subscription, FileHandlerTransactionLog]] = []
 

--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -304,7 +304,7 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
     args, extra_args = parser.parse_known_args()
 
     # Load the config
-    config: ConfigFile = ConfigFile(name="config", value={})
+    config: ConfigFile = ConfigFile(name="default_config", value={})
     if args.config:
         config = ConfigFile.from_file_path(args.config)
     elif os.path.isfile(DEFAULT_CONFIG_FILE_NAME):

--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -310,7 +310,7 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
     elif os.path.isfile(DEFAULT_CONFIG_FILE_NAME):
         config = ConfigFile.from_file_path(DEFAULT_CONFIG_FILE_NAME)
     else:
-        logger.info("No config specified, using defaults")
+        logger.info("No config specified, using defaults.")
 
     transaction_logs: List[Tuple[Subscription, FileHandlerTransactionLog]] = []
 

--- a/src/ytdl_sub/cli/main.py
+++ b/src/ytdl_sub/cli/main.py
@@ -11,7 +11,7 @@ from colorama import Fore
 from yt_dlp.utils import sanitize_filename
 
 from ytdl_sub.cli.download_args_parser import DownloadArgsParser
-from ytdl_sub.cli.main_args_parser import parser
+from ytdl_sub.cli.main_args_parser import parser, DEFAULT_CONFIG_FILE_NAME
 from ytdl_sub.config.config_file import ConfigFile
 from ytdl_sub.subscriptions.subscription import Subscription
 from ytdl_sub.utils.exceptions import ExperimentalFeatureNotEnabled
@@ -303,7 +303,14 @@ def main() -> List[Tuple[Subscription, FileHandlerTransactionLog]]:
     args, extra_args = parser.parse_known_args()
 
     # Load the config
-    config: ConfigFile = ConfigFile.from_file_path(args.config)
+    config: ConfigFile = ConfigFile(name="config", value={})
+    if args.config:
+        config = ConfigFile.from_file_path(args.config)
+    elif os.path.isfile(DEFAULT_CONFIG_FILE_NAME):
+        config = ConfigFile.from_file_path(DEFAULT_CONFIG_FILE_NAME)
+    else:
+        logger.debug("No config specified, using defaults")
+
     transaction_logs: List[Tuple[Subscription, FileHandlerTransactionLog]] = []
 
     # If transaction log file is specified, make sure we can open it

--- a/src/ytdl_sub/cli/main_args_parser.py
+++ b/src/ytdl_sub/cli/main_args_parser.py
@@ -88,8 +88,8 @@ def _add_shared_arguments(arg_parser: argparse.ArgumentParser, suppress_defaults
         MainArguments.CONFIG.long,
         metavar="CONFIGPATH",
         type=str,
-        # Default is set downstream
         help=f"path to the config yaml, uses {DEFAULT_CONFIG_FILE_NAME} if not provided",
+        default=argparse.SUPPRESS if suppress_defaults else None,  # Default is set downstream
     )
     arg_parser.add_argument(
         MainArguments.DRY_RUN.short,

--- a/src/ytdl_sub/cli/main_args_parser.py
+++ b/src/ytdl_sub/cli/main_args_parser.py
@@ -5,6 +5,8 @@ from typing import List
 from ytdl_sub import __local_version__
 from ytdl_sub.utils.logger import LoggerLevels
 
+DEFAULT_CONFIG_FILE_NAME: str = "config.yaml"
+
 
 @dataclasses.dataclass
 class CLIArgument:
@@ -86,8 +88,8 @@ def _add_shared_arguments(arg_parser: argparse.ArgumentParser, suppress_defaults
         MainArguments.CONFIG.long,
         metavar="CONFIGPATH",
         type=str,
-        help="path to the config yaml, uses config.yaml if not provided",
-        default=argparse.SUPPRESS if suppress_defaults else "config.yaml",
+        # Default is set downstream
+        help=f"path to the config yaml, uses {DEFAULT_CONFIG_FILE_NAME} if not provided",
     )
     arg_parser.add_argument(
         MainArguments.DRY_RUN.short,

--- a/src/ytdl_sub/config/config_file.py
+++ b/src/ytdl_sub/config/config_file.py
@@ -11,7 +11,6 @@ from ytdl_sub.validators.file_path_validators import FilePathValidatorMixin
 
 
 class ConfigFile(ConfigValidator):
-
     def __init__(self, name: str, value: Any):
         super().__init__(name, value)
 

--- a/src/ytdl_sub/config/config_file.py
+++ b/src/ytdl_sub/config/config_file.py
@@ -43,18 +43,19 @@ class ConfigFile(ConfigValidator):
         return self
 
     @classmethod
-    def from_dict(cls, config_dict: dict) -> "ConfigFile":
+    def from_dict(cls, config_dict: dict, name: str = "") -> "ConfigFile":
         """
         Parameters
         ----------
         config_dict:
             The config in dictionary format
-
+        name:
+            Name of the config
         Returns
         -------
         Config file validator
         """
-        return ConfigFile(name="", value=config_dict)
+        return ConfigFile(name=name, value=config_dict)
 
     @classmethod
     def from_file_path(cls, config_path: str) -> "ConfigFile":
@@ -81,7 +82,7 @@ class ConfigFile(ConfigValidator):
                 f"Did you set --config correctly?"
             ) from exc
 
-        return ConfigFile.from_dict(config_dict)
+        return ConfigFile.from_dict(name=config_path, config_dict=config_dict)
 
     def as_dict(self) -> Dict[str, Any]:
         """

--- a/src/ytdl_sub/config/config_file.py
+++ b/src/ytdl_sub/config/config_file.py
@@ -11,7 +11,6 @@ from ytdl_sub.validators.file_path_validators import FilePathValidatorMixin
 
 
 class ConfigFile(ConfigValidator):
-    _required_keys = {"configuration", "presets"}
 
     def __init__(self, name: str, value: Any):
         super().__init__(name, value)

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -113,7 +113,9 @@ class ConfigOptions(StrictDictValidator):
         super().__init__(name, value)
 
         self._working_directory = self._validate_key_if_present(
-            key="working_directory", validator=StringValidator, default=".ytdl-sub-temp-directory"
+            key="working_directory",
+            validator=StringValidator,
+            default=".ytdl-sub-working-directory",
         )
         self._umask = self._validate_key_if_present(
             key="umask", validator=StringValidator, default="022"

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -96,8 +96,8 @@ class PersistLogsValidator(StrictDictValidator):
 
 
 class ConfigOptions(StrictDictValidator):
-    _required_keys = {"working_directory"}
     _optional_keys = {
+        "working_directory",
         "umask",
         "dl_aliases",
         "persist_logs",
@@ -112,8 +112,8 @@ class ConfigOptions(StrictDictValidator):
     def __init__(self, name: str, value: Any):
         super().__init__(name, value)
 
-        self._working_directory = self._validate_key(
-            key="working_directory", validator=StringValidator
+        self._working_directory = self._validate_key_if_present(
+            key="working_directory", validator=StringValidator, default=".ytdl-sub-temp-directory"
         )
         self._umask = self._validate_key_if_present(
             key="umask", validator=StringValidator, default="022"
@@ -244,14 +244,16 @@ class ConfigOptions(StrictDictValidator):
 
 
 class ConfigValidator(StrictDictValidator):
-    _required_keys = {"configuration", "presets"}
+    _optional_keys = {"configuration", "presets"}
 
     def __init__(self, name: str, value: Any):
         super().__init__(name, value)
-        self.config_options = self._validate_key("configuration", ConfigOptions)
+        self.config_options = self._validate_key_if_present(
+            "configuration", ConfigOptions, default={}
+        )
 
         # Make sure presets is a dictionary. Will be validated in `PresetValidator`
-        self.presets = self._validate_key("presets", LiteralDictValidator)
+        self.presets = self._validate_key_if_present("presets", LiteralDictValidator, default={})
 
         # Ensure custom presets do not collide with prebuilt presets
         for preset_name in self.presets.keys:

--- a/tests/e2e/plugins/internal/test_view.py
+++ b/tests/e2e/plugins/internal/test_view.py
@@ -10,12 +10,11 @@ class TestView:
     @pytest.mark.parametrize("split_chapters", [True, False])
     def test_view_from_cli(
         self,
-        music_video_config_path,
         output_directory,
         split_chapters,
     ):
 
-        args = f"--config {music_video_config_path} view "
+        args = f"view "
         args += "--split-chapters " if split_chapters else ""
         args += f"https://www.youtube.com/playlist?list=PLBsm_SagFMmdWnCnrNtLjA9kzfrRkto4i"
         subscription_transaction_log = mock_run_from_cli(args=args)

--- a/tests/e2e/youtube/test_playlist.py
+++ b/tests/e2e/youtube/test_playlist.py
@@ -150,19 +150,18 @@ class TestPlaylist:
             )
 
     @pytest.mark.parametrize("dry_run", [True, False])
-    def test_playlist_download_from_cli_sub(
+    def test_playlist_download_from_cli_sub_no_provided_config(
         self,
         preset_dict_to_subscription_yaml_generator,
-        music_video_config_for_cli,
         playlist_preset_dict,
         output_directory,
         dry_run,
     ):
+        # No config needed when using only prebuilt presets
         with preset_dict_to_subscription_yaml_generator(
             subscription_name="music_video_playlist_test", preset_dict=playlist_preset_dict
         ) as subscription_path:
             args = "--dry-run " if dry_run else ""
-            args += f"--config {music_video_config_for_cli} "
             args += f"sub {subscription_path}"
             subscription_transaction_log = mock_run_from_cli(args=args)
 

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -97,6 +97,19 @@ def test_args_after_sub_work(mock_sys_exit):
         assert Logger._LOGGER_LEVEL == LoggerLevels.VERBOSE
 
 
+def test_no_config_works(mock_sys_exit):
+    with mock_sys_exit(expected_exit_code=0), patch.object(
+        sys,
+        "argv",
+        ["ytdl-sub", "sub", "--log-level", "verbose"],
+    ), patch("ytdl_sub.cli.main._download_subscriptions_from_yaml_files") as mock_sub:
+        main()
+
+        assert mock_sub.call_count == 1
+        assert mock_sub.call_args.kwargs["subscription_paths"] == ["subscriptions.yaml"]
+        assert Logger._LOGGER_LEVEL == LoggerLevels.VERBOSE
+
+
 def test_no_positional_arg_command(mock_sys_exit):
     with mock_sys_exit(expected_exit_code=1), patch.object(
         sys,


### PR DESCRIPTION
The only required field in a config was `working_directory`. This is now optional (defaults to `.ytdl-sub-working-directory`) making it so a config is no longer required. This sets the stage to onboard noob users who will solely use prebuilt presets