### PR TITLE
[FEATURE] Extend subscription syntax

### DIFF
--- a/examples/tv_show_subscriptions.yaml
+++ b/examples/tv_show_subscriptions.yaml
@@ -13,12 +13,12 @@ TV Show Full Archive:
     "Opeth": "https://www.youtube.com/channel/UCmQSJTFZaXN85gYk6W3XbdQ"
 
   # Sets "Kids" for genre, "TV-Y" for content rating
-  = Kids | TV-Y:
+  = Kids | = TV-Y:
     "Jake Trains": "https://www.youtube.com/@JakeTrains"
     "Kids Toys Play": "https://www.youtube.com/@KidsToysPlayChannel"
 
 
 # All subscriptions under this will use the `TV Show Only Recent` preset
 TV Show Only Recent:
-  = News | TV-14:
+  = News | = TV-14:
     "BBC": "https://www.youtube.com/@BBCNews"

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -10,6 +10,7 @@ from ytdl_sub.config.defaults import DEFAULT_FFPROBE_PATH
 from ytdl_sub.config.defaults import DEFAULT_LOCK_DIRECTORY
 from ytdl_sub.config.defaults import MAX_FILE_NAME_BYTES
 from ytdl_sub.prebuilt_presets import PREBUILT_PRESETS
+from ytdl_sub.subscriptions.utils import SUBSCRIPTION_VALUE_CONFIG_KEY
 from ytdl_sub.validators.file_path_validators import FFmpegFileValidator
 from ytdl_sub.validators.file_path_validators import FFprobeFileValidator
 from ytdl_sub.validators.strict_dict_validator import StrictDictValidator
@@ -106,7 +107,7 @@ class ConfigOptions(StrictDictValidator):
         "ffprobe_path",
         "file_name_max_bytes",
         "experimental",
-        "subscription_value",
+        SUBSCRIPTION_VALUE_CONFIG_KEY,
     }
 
     def __init__(self, name: str, value: Any):
@@ -142,7 +143,7 @@ class ConfigOptions(StrictDictValidator):
             key="file_name_max_bytes", validator=IntValidator, default=MAX_FILE_NAME_BYTES
         )
         self._subscription_value = self._validate_key_if_present(
-            key="subscription_value", validator=StringValidator
+            key=SUBSCRIPTION_VALUE_CONFIG_KEY, validator=StringValidator
         )
 
     @property

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -175,11 +175,12 @@ class Overrides(DictFormatterValidator):
             )
 
         if SUBSCRIPTION_NAME not in self._value:
-            self._add_override_variable(
-                key_name=SUBSCRIPTION_NAME,
-                format_string=self.subscription_name,
-                sanitize=True,
-            )
+            for sanitized in [True, False]:
+                self._add_override_variable(
+                    key_name=SUBSCRIPTION_NAME,
+                    format_string=self.subscription_name,
+                    sanitize=sanitized,
+                )
 
     @property
     def subscription_name(self) -> str:

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -9,6 +9,7 @@ from yt_dlp.utils import sanitize_filename
 
 from ytdl_sub.config.defaults import DEFAULT_DOWNLOAD_ARCHIVE_NAME
 from ytdl_sub.entries.entry import Entry
+from ytdl_sub.subscriptions.utils import SUBSCRIPTION_NAME
 from ytdl_sub.utils.exceptions import ValidationException
 from ytdl_sub.validators.file_path_validators import OverridesStringFormatterFilePathValidator
 from ytdl_sub.validators.file_path_validators import StringFormatterFileNameValidator
@@ -172,6 +173,22 @@ class Overrides(DictFormatterValidator):
                 format_string=self._value[key].format_string,
                 sanitize=True,
             )
+
+        if SUBSCRIPTION_NAME not in self._value:
+            self._add_override_variable(
+                key_name=SUBSCRIPTION_NAME,
+                format_string=self.subscription_name,
+                sanitize=True,
+            )
+
+    @property
+    def subscription_name(self) -> str:
+        """
+        Returns
+        -------
+        Name of the subscription
+        """
+        return self._root_name
 
     def apply_formatter(
         self,

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -120,45 +120,9 @@ class YTDLOptions(LiteralDictValidator):
     """
 
 
-class OverridesVariables(DictFormatterValidator):
-    """
-    Override variables that are automatically added to every subscription.
-    """
-
-    def _add_override_variable(self, key_name: str, format_string: str, sanitize: bool = False):
-        if sanitize:
-            key_name = f"{key_name}_sanitized"
-            format_string = sanitize_filename(format_string)
-
-        self._value[key_name] = StringFormatterValidator(
-            name="__should_never_fail__",
-            value=format_string,
-        )
-
-    def __init__(self, name, value):
-        super().__init__(name, value)
-
-        # Add sanitized and non-sanitized override variables
-        for sanitize in [True, False]:
-            self._add_override_variable(
-                key_name="subscription_name",
-                format_string=self.subscription_name,
-                sanitize=sanitize,
-            )
-
-    @property
-    def subscription_name(self) -> str:
-        """
-        Returns
-        -------
-        Name of the subscription
-        """
-        return self._root_name
-
-
 # Disable for proper docstring formatting
 # pylint: disable=line-too-long
-class Overrides(OverridesVariables):
+class Overrides(DictFormatterValidator):
     """
     Optional. This section allows you to define variables that can be used in any string formatter.
     For example, if you want your file and thumbnail files to match without copy-pasting a large
@@ -187,6 +151,16 @@ class Overrides(OverridesVariables):
     """
 
     # pylint: enable=line-too-long
+
+    def _add_override_variable(self, key_name: str, format_string: str, sanitize: bool = False):
+        if sanitize:
+            key_name = f"{key_name}_sanitized"
+            format_string = sanitize_filename(format_string)
+
+        self._value[key_name] = StringFormatterValidator(
+            name="__should_never_fail__",
+            value=format_string,
+        )
 
     def __init__(self, name, value):
         super().__init__(name, value)

--- a/src/ytdl_sub/subscriptions/subscription_validators.py
+++ b/src/ytdl_sub/subscriptions/subscription_validators.py
@@ -9,34 +9,15 @@ from typing import final
 
 from ytdl_sub.config.config_file import ConfigFile
 from ytdl_sub.config.preset_options import Overrides
+from ytdl_sub.subscriptions.utils import SUBSCRIPTION_NAME
+from ytdl_sub.subscriptions.utils import SUBSCRIPTION_VALUE
+from ytdl_sub.subscriptions.utils import subscription_indent_variable_name
+from ytdl_sub.subscriptions.utils import subscription_list_variable_name
 from ytdl_sub.validators.string_formatter_validators import DictFormatterValidator
 from ytdl_sub.validators.validators import DictValidator
 from ytdl_sub.validators.validators import StringListValidator
 from ytdl_sub.validators.validators import StringValidator
 from ytdl_sub.validators.validators import Validator
-
-
-def subscription_indent_variable_name(index: int) -> str:
-    """
-    Parameters
-    ----------
-    index
-        0th-based index
-
-    Returns
-    -------
-    subscription_index_i, where i is 1-based index
-    """
-    return f"subscription_indent_{index + 1}"
-
-
-def subscription_value_variable_name() -> str:
-    """
-    Returns
-    -------
-    The override variable name containing the subscription value if present
-    """
-    return "subscription_value"
 
 
 class SubscriptionOutput(Validator, ABC):
@@ -95,7 +76,7 @@ class SubscriptionPresetDictValidator(SubscriptionOutput, DictValidator):
         output_dict["overrides"] = dict(
             output_dict.get("overrides", {}),
             **self._indent_overrides_dict(),
-            **{"subscription_name": self.subscription_name},
+            **{SUBSCRIPTION_NAME: self.subscription_name},
         )
         return {self.subscription_name: output_dict}
 
@@ -117,7 +98,7 @@ class SubscriptionLeafValidator(SubscriptionOutput, ABC):
                 f"used as a subscription name"
             )
 
-        self._overrides_to_add: Dict[str, str] = {"subscription_name": self.subscription_name}
+        self._overrides_to_add: Dict[str, str] = {SUBSCRIPTION_NAME: self.subscription_name}
 
     @final
     def subscription_dicts(self, global_presets_to_apply: List[str]) -> Dict[str, Dict]:
@@ -153,7 +134,7 @@ class SubscriptionValueValidator(SubscriptionLeafValidator, StringValidator):
         # TODO: Eventually delete in favor of {subscription_value}
         if subscription_value:
             self._overrides_to_add[subscription_value] = self.value
-        self._overrides_to_add["subscription_value"] = self.value
+        self._overrides_to_add[SUBSCRIPTION_VALUE] = self.value
 
 
 class SubscriptionListValuesValidator(SubscriptionLeafValidator, StringListValidator):
@@ -176,8 +157,9 @@ class SubscriptionListValuesValidator(SubscriptionLeafValidator, StringListValid
         for idx, list_value in enumerate(self.list):
             # Write the first list value into subscription_value as well
             if idx == 0:
-                self._overrides_to_add["subscription_value"] = list_value.value
-            self._overrides_to_add[f"subscription_value_{idx + 1}"] = list_value.value
+                self._overrides_to_add[SUBSCRIPTION_VALUE] = list_value.value
+
+            self._overrides_to_add[subscription_list_variable_name(index=idx)] = list_value.value
 
 
 class SubscriptionWithOverridesValidator(SubscriptionLeafValidator, DictFormatterValidator):

--- a/src/ytdl_sub/subscriptions/utils.py
+++ b/src/ytdl_sub/subscriptions/utils.py
@@ -1,0 +1,33 @@
+SUBSCRIPTION_NAME = "subscription_name"
+SUBSCRIPTION_VALUE = "subscription_value"
+
+# Key used in configs, should delete at some point
+SUBSCRIPTION_VALUE_CONFIG_KEY = "subscription_value"
+
+
+def subscription_indent_variable_name(index: int) -> str:
+    """
+    Parameters
+    ----------
+    index
+        0th-based index
+
+    Returns
+    -------
+    subscription_index_i, where i is 1-based index
+    """
+    return f"subscription_indent_{index + 1}"
+
+
+def subscription_list_variable_name(index: int) -> str:
+    """
+    Parameters
+    ----------
+    index
+        0th-based index
+
+    Returns
+    -------
+    subscription_value_i, where i is 1-based index
+    """
+    return f"subscription_value_{index + 1}"

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -123,6 +123,25 @@ def preset_with_subscription_value_nested_presets_and_indent_variables_same_line
             "parent_preset_2": {
                 "=INDENT_1": {
                     "parent_preset_1": {"test_2_1": "is_2_1_overwritten"},
+                    "= INDENT_2  | = INDENT_3   ": {
+                        "test_1": "is_1_overwritten",
+                    },
+                }
+            }
+        },
+    )
+
+
+@pytest.fixture
+def preset_with_subscription_value_nested_presets_and_indent_variables_same_line_old_format_errors(
+    preset_with_subscription_value: Dict,
+):
+    return dict(
+        preset_with_subscription_value,
+        **{
+            "parent_preset_2": {
+                "=INDENT_1": {
+                    "parent_preset_1": {"test_2_1": "is_2_1_overwritten"},
                     "= INDENT_2  | INDENT_3   ": {
                         "test_1": "is_1_overwritten",
                     },
@@ -191,6 +210,7 @@ def test_subscription_file_value_applies_sub_file_takes_precedence(
     assert value_sub.get("test_file_subscription_value") == "is_overwritten"
     assert value_sub.get("test_config_subscription_value") == "original"
     assert value_sub.get("subscription_name") == "test_value"
+    assert value_sub.get("subscription_name_sanitized") == "test_value"
     assert value_sub.get("subscription_value") == "is_overwritten"
     assert value_sub.get("current_override") == "__preset__"  # ensure __preset__ takes precedence
 
@@ -209,6 +229,7 @@ def test_subscription_file_value_applies_from_config(
     assert value_sub.get("test_file_subscription_value") == "original"
     assert value_sub.get("test_config_subscription_value") == "is_overwritten"
     assert value_sub.get("subscription_name") == "test_value"
+    assert value_sub.get("subscription_name_sanitized") == "test_value"
     assert value_sub.get("subscription_value") == "is_overwritten"
     assert value_sub.get("current_override") == "__preset__"  # ensure __preset__ takes precedence
 
@@ -229,11 +250,13 @@ def test_subscription_file_value_applies_from_config_and_nested(
 
     assert sub_1.get("test_config_subscription_value") == "is_1_overwritten"
     assert sub_1.get("subscription_name") == "test_1"
+    assert sub_1.get("subscription_name_sanitized") == "test_1"
     assert sub_1.get("subscription_value") == "is_1_overwritten"
     assert sub_1.get("current_override") == "__preset__"  # ensure __preset__ takes precedence
 
     assert sub_2_1.get("test_config_subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("subscription_name") == "test_2_1"
+    assert sub_2_1.get("subscription_name_sanitized") == "test_2_1"
     assert sub_2_1.get("subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("current_override") == "__preset__"  # ensure __preset__ takes precedence
 
@@ -262,6 +285,7 @@ def test_subscription_file_value_applies_from_config_and_nested_and_indent_varia
 
     assert sub_1.get("test_config_subscription_value") == "is_1_overwritten"
     assert sub_1.get("subscription_name") == "test_1"
+    assert sub_1.get("subscription_name_sanitized") == "test_1"
     assert sub_1.get("subscription_value") == "is_1_overwritten"
     assert sub_1.get("subscription_indent_1") == "INDENT_1"
     assert sub_1.get("subscription_indent_2") == "INDENT_2"
@@ -269,6 +293,7 @@ def test_subscription_file_value_applies_from_config_and_nested_and_indent_varia
 
     assert sub_2_1.get("test_config_subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("subscription_name") == "test_2_1"
+    assert sub_2_1.get("subscription_name_sanitized") == "test_2_1"
     assert sub_2_1.get("subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("subscription_indent_1") == "INDENT_1"
     assert sub_2_1.get("subscription_indent_2") == "original_2"
@@ -299,6 +324,7 @@ def test_subscription_file_value_applies_from_config_and_nested_and_indent_varia
 
     assert sub_1.get("test_config_subscription_value") == "is_1_overwritten"
     assert sub_1.get("subscription_name") == "test_1"
+    assert sub_1.get("subscription_name_sanitized") == "test_1"
     assert sub_1.get("subscription_value") == "is_1_overwritten"
     assert sub_1.get("subscription_indent_1") == "INDENT_1"
     assert sub_1.get("subscription_indent_2") == "INDENT_2"
@@ -307,11 +333,30 @@ def test_subscription_file_value_applies_from_config_and_nested_and_indent_varia
 
     assert sub_2_1.get("test_config_subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("subscription_name") == "test_2_1"
+    assert sub_2_1.get("subscription_name_sanitized") == "test_2_1"
     assert sub_2_1.get("subscription_value") == "is_2_1_overwritten"
     assert sub_2_1.get("subscription_indent_1") == "INDENT_1"
     assert sub_2_1.get("subscription_indent_2") == "original_2"
     assert sub_2_1.get("current_override") == "__preset__"  # ensure __preset__ takes precedence
     assert "subscription_indent_3" not in sub_2_1
+
+
+def test_subscription_file_value_applies_from_config_and_nested_and_indent_variables_same_line_old_format_errors(
+    config_file_with_subscription_value: ConfigFile,
+    preset_with_subscription_value_nested_presets_and_indent_variables_same_line_old_format_errors: Dict,
+):
+    with mock_load_yaml(
+        preset_dict=preset_with_subscription_value_nested_presets_and_indent_variables_same_line_old_format_errors
+    ), pytest.raises(
+        ValidationException,
+        match=re.escape(
+            "Validation error in parent_preset_2.=INDENT_1: 'INDENT_3' in '= INDENT_2  | INDENT_3' is not a preset name. "
+            "To use as a subscription indent value, define it as '= INDENT_3'"
+        ),
+    ):
+        Subscription.from_file_path(
+            config=config_file_with_subscription_value, subscription_path="mocked"
+        )
 
 
 def test_subscription_file_bad_value(config_file: ConfigFile):
@@ -346,7 +391,7 @@ def test_subscription_file_using_conflicting_preset_name(config_file: ConfigFile
 def test_subscription_file_invalid_form(config_file: ConfigFile):
     with mock_load_yaml(preset_dict={"sub_name": 4332}), pytest.raises(
         ValidationException,
-        match=re.escape(f"Validation error in sub_name: should be of type object."),
+        match=re.escape(f"Subscription value should either be a string, list, or object"),
     ):
         _ = Subscription.from_file_path(config=config_file, subscription_path="mocked")
 
@@ -363,6 +408,7 @@ def test_tv_show_subscriptions(
     jake_train_overrides = subs[2].overrides.dict_with_format_strings
 
     assert jake_train_overrides["subscription_name"] == "Jake Trains"
+    assert jake_train_overrides["subscription_name_sanitized"] == "Jake Trains"
     assert jake_train_overrides["subscription_value"] == "https://www.youtube.com/@JakeTrains"
     assert jake_train_overrides["subscription_indent_1"] == "Kids"
     assert jake_train_overrides["subscription_indent_2"] == "TV-Y"
@@ -378,6 +424,7 @@ def test_music_subscriptions(default_config: ConfigFile, music_subscriptions_pat
     monk = subs[2].overrides.dict_with_format_strings
 
     assert monk["subscription_name"] == "Stan Getz"
+    assert monk["subscription_name_sanitized"] == "Stan Getz"
     assert monk["subscription_value"] == "https://www.youtube.com/@stangetzofficial/releases"
     assert monk["subscription_indent_1"] == "Jazz"
 
@@ -392,6 +439,7 @@ def test_music_video_subscriptions(default_config: ConfigFile, music_video_subsc
     monk = subs[1].overrides.dict_with_format_strings
 
     assert monk["subscription_name"] == "Michael Jackson"
+    assert monk["subscription_name_sanitized"] == "Michael Jackson"
     assert (
         monk["subscription_value"]
         == "https://www.youtube.com/playlist?list=OLAK5uy_mnY03zP6abNWH929q2XhGzWD_2uKJ_n8E"


### PR DESCRIPTION
Extends the subscription.yaml syntax at the cost of introducing a breaking change.

# New Syntax
## Mix-n-match presets and indent variables
```
# Can mix/match presets and indent override variables.
# Uses presets TV Show, Only Recent and assigns Kids, TV-Y to subscription_indent_1 and _2
TV Show | = Kids | = TV-Y | Only Recent:
  "Jake Trains": "https://..."
```

## Subscriptions with list-value support
```
TV Show | = Kids | = TV-Y | Only Recent:
  "Jake Trains":
    - "https://url.1..."  # Assigns to subscription_value and subscription_value_1
    - "https://url.2..."  # Assigns to subscription_value_2
```

## Subscriptions with override-keys support
```
TV Show | = Kids | = TV-Y | Only Recent:
  "~Jake Trains":  # the ~ means "all keys underneath get assigned as override variables"
    url: "https://url.1..."  # Assigns to url
    url2: "https://url.2..."  # Assigns to url2
```

# Breaking Changes
In the TV show subscriptions example (https://github.com/jmbannon/ytdl-sub/blob/master/examples/tv_show_subscriptions.yaml), it had
```
TV Show Full Archive:
  # Sets "Kids" for genre, "TV-Y" for content rating
  = Kids | TV-Y:
    "Jake Trains": "https://www.youtube.com/@JakeTrains"
    "Kids Toys Play": "https://www.youtube.com/@KidsToysPlayChannel"
```
This must be changed to
```
TV Show Full Archive:
  # Sets "Kids" for genre, "TV-Y" for content rating
  = Kids | = TV-Y:  # Each indent variable assignment must have an = before it
    "Jake Trains": "https://www.youtube.com/@JakeTrains"
    "Kids Toys Play": "https://www.youtube.com/@KidsToysPlayChannel"
```