### PR TITLE
[BUGFIX]: File convert plugin deletes output file

### DIFF
--- a/src/ytdl_sub/plugins/file_convert.py
+++ b/src/ytdl_sub/plugins/file_convert.py
@@ -193,9 +193,9 @@ class FileConvertPlugin(Plugin[FileConvertOptions]):
                         "file_convert ffmpeg_post_process_args did not produce an output file"
                     )
 
+                FileHandler.delete(input_video_file_path)
                 FileHandler.move(tmp_output_file, converted_video_file_path)
                 FileHandler.delete(tmp_output_file)
-                FileHandler.delete(input_video_file_path)
 
         if original_ext != new_ext:
             entry.add_kwargs(


### PR DESCRIPTION
Whenever the input file and converted file have the same name, the file convert plugin will delete the output file.  Fixed by moving the deletion of the input file before renaming the temporary file to the desired output name.