### PR TITLE
[BACKEND] Make sibling metadata optional to compute

### DIFF
--- a/src/ytdl_sub/downloaders/url/downloader.py
+++ b/src/ytdl_sub/downloaders/url/downloader.py
@@ -385,7 +385,9 @@ class MultiUrlDownloader(SourcePlugin[MultiUrlValidator]):
             ):
                 yield entry_child
 
-    def _download_url_metadata(self, url: str) -> Tuple[List[EntryParent], List[Entry]]:
+    def _download_url_metadata(
+        self, url: str, include_sibling_metadata: bool
+    ) -> Tuple[List[EntryParent], List[Entry]]:
         """
         Downloads only info.json files and forms EntryParent trees
         """
@@ -401,6 +403,7 @@ class MultiUrlDownloader(SourcePlugin[MultiUrlValidator]):
             url=url,
             entry_dicts=entry_dicts,
             working_directory=self.working_directory,
+            include_sibling_metadata=include_sibling_metadata,
         )
         orphans = EntryParent.from_entry_dicts_with_no_parents(
             parents=parents,
@@ -438,7 +441,9 @@ class MultiUrlDownloader(SourcePlugin[MultiUrlValidator]):
             if not (url := self.overrides.apply_formatter(collection_url.url)):
                 continue
 
-            parents, orphan_entries = self._download_url_metadata(url=url)
+            parents, orphan_entries = self._download_url_metadata(
+                url=url, include_sibling_metadata=collection_url.include_sibling_metadata
+            )
 
             # TODO: Encapsulate this logic into its own class
             self._url_state = URLDownloadState(

--- a/src/ytdl_sub/downloaders/url/validators.py
+++ b/src/ytdl_sub/downloaders/url/validators.py
@@ -45,7 +45,13 @@ class UrlThumbnailListValidator(ListValidator[UrlThumbnailValidator]):
 
 class UrlValidator(StrictDictValidator):
     _required_keys = {"url"}
-    _optional_keys = {"variables", "source_thumbnails", "playlist_thumbnails", "download_reverse"}
+    _optional_keys = {
+        "variables",
+        "source_thumbnails",
+        "playlist_thumbnails",
+        "download_reverse",
+        "include_sibling_metadata",
+    }
 
     @classmethod
     def partial_validate(cls, name: str, value: Any) -> None:
@@ -73,6 +79,9 @@ class UrlValidator(StrictDictValidator):
         )
         self._download_reverse = self._validate_key(
             key="download_reverse", validator=BoolValidator, default=True
+        )
+        self._include_sibling_metadata = self._validate_key(
+            key="include_sibling_metadata", validator=BoolValidator, default=False
         )
 
     @property
@@ -146,6 +155,16 @@ class UrlValidator(StrictDictValidator):
         Defaults to True.
         """
         return self._download_reverse.value
+
+    @property
+    def include_sibling_metadata(self) -> bool:
+        """
+        Optional. Whether to include sibling metadata as an entry variable, which comprises basic
+        metadata from all other entries (including itself) that belong to the same playlist. For
+        channels or large playlists, this becomes memory-intensive since you are storing
+        ``n^2`` metadata. Defaults to False.
+        """
+        return self._include_sibling_metadata.value
 
 
 class UrlStringOrDictValidator(UrlValidator):

--- a/src/ytdl_sub/prebuilt_presets/music/music.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music/music.yaml
@@ -68,12 +68,16 @@ presets:
 
     download:
       - url: "{url}"
-        include_sibling_metadata: True
+        include_sibling_metadata: False
 
 
   _albums_from_playlists:
     preset:
-      - "Single"
+      - "_music_base"
+
+    download:
+      - url: "{url}"
+        include_sibling_metadata: True
 
     overrides:
       track_album: "{playlist_title}"

--- a/src/ytdl_sub/prebuilt_presets/music/music.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music/music.yaml
@@ -67,7 +67,8 @@ presets:
       - "_music_base"
 
     download:
-      - "{url}"
+      - url: "{url}"
+        include_sibling_metadata: True
 
 
   _albums_from_playlists:
@@ -107,6 +108,7 @@ presets:
         # The first URL will be all the artist's tracks.
         # Treat these as singles - an album with a single track
         - url: "{url}/tracks"
+          include_sibling_metadata: False
           variables:
             sc_track_album: "{title}"
             sc_track_number: "1"
@@ -117,6 +119,7 @@ presets:
         # to an album and tracks (in the URL above), it will resolve to this
         # URL and include the album metadata we set below.
         - url: "{url}/albums"
+          include_sibling_metadata: True
           variables:
             sc_track_album: "{playlist_title}"
             sc_track_number: "{playlist_index}"

--- a/tests/unit/config/test_config_file.py
+++ b/tests/unit/config/test_config_file.py
@@ -73,8 +73,8 @@ class TestConfigFilePartiallyValidatesPresets:
             preset_dict={"download": {"bad_key": "nope"}},
             expected_error_message="Validation error in partial_preset.download.1: "
             "'partial_preset.download.1' contains the field 'bad_key' which is not allowed. "
-            "Allowed fields: download_reverse, playlist_thumbnails, source_thumbnails, url, "
-            "variables",
+            "Allowed fields: download_reverse, include_sibling_metadata, playlist_thumbnails, "
+            "source_thumbnails, url, variables",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Partial fix to https://github.com/jmbannon/ytdl-sub/issues/853
Makes computing sibling metadata optional, defaulted to False. This prevents excessive memory usage when scraping large channels