### PR TITLE
[BUGFIX] Fix periods not working in subscription names

### DIFF
--- a/src/ytdl_sub/subscriptions/subscription_validators.py
+++ b/src/ytdl_sub/subscriptions/subscription_validators.py
@@ -46,19 +46,26 @@ class SubscriptionOutput(Validator, ABC):
         Subscriptions in the form of ``{ subscription_name: preset_dict }``
         """
 
-    @property
-    def subscription_name(self) -> str:
-        """
-        Returns
-        -------
-        The name of the subscription
-        """
-        return self._leaf_name
 
-
-class SubscriptionPresetDictValidator(SubscriptionOutput, DictValidator):
-    def __init__(self, name, value, presets: List[str], indent_overrides: List[str]):
+class NamedSubscriptionValidator(SubscriptionOutput, ABC):
+    def __init__(
+        self, name, value, subscription_name: str, presets: List[str], indent_overrides: List[str]
+    ):
         super().__init__(name=name, value=value, presets=presets, indent_overrides=indent_overrides)
+        self.subscription_name = subscription_name
+
+
+class SubscriptionPresetDictValidator(NamedSubscriptionValidator, DictValidator):
+    def __init__(
+        self, name, value, subscription_name: str, presets: List[str], indent_overrides: List[str]
+    ):
+        super().__init__(
+            name=name,
+            value=value,
+            subscription_name=subscription_name,
+            presets=presets,
+            indent_overrides=indent_overrides,
+        )
 
         _ = self._validate_key_if_present(key="preset", validator=StringListValidator, default=[])
         _ = self._validate_key_if_present(key="overrides", validator=Overrides, default={})
@@ -80,16 +87,23 @@ class SubscriptionPresetDictValidator(SubscriptionOutput, DictValidator):
         return {self.subscription_name: output_dict}
 
 
-class SubscriptionLeafValidator(SubscriptionOutput, ABC):
+class SubscriptionLeafValidator(NamedSubscriptionValidator, ABC):
     def __init__(
         self,
         name,
         value,
+        subscription_name: str,
         config: ConfigFile,
         presets: List[str],
         indent_overrides: List[str],
     ):
-        super().__init__(name=name, value=value, presets=presets, indent_overrides=indent_overrides)
+        super().__init__(
+            name=name,
+            value=value,
+            subscription_name=subscription_name,
+            presets=presets,
+            indent_overrides=indent_overrides,
+        )
 
         if self.subscription_name in config.presets.keys:
             raise self._validation_exception(
@@ -117,6 +131,7 @@ class SubscriptionValueValidator(SubscriptionLeafValidator, StringValidator):
         self,
         name,
         value,
+        subscription_name: str,
         config: ConfigFile,
         presets: List[str],
         indent_overrides: List[str],
@@ -124,6 +139,7 @@ class SubscriptionValueValidator(SubscriptionLeafValidator, StringValidator):
         super().__init__(
             name=name,
             value=value,
+            subscription_name=subscription_name,
             config=config,
             presets=presets,
             indent_overrides=indent_overrides,
@@ -136,6 +152,7 @@ class SubscriptionListValuesValidator(SubscriptionLeafValidator, StringListValid
         self,
         name,
         value,
+        subscription_name: str,
         config: ConfigFile,
         presets: List[str],
         indent_overrides: List[str],
@@ -143,6 +160,7 @@ class SubscriptionListValuesValidator(SubscriptionLeafValidator, StringListValid
         super().__init__(
             name=name,
             value=value,
+            subscription_name=subscription_name,
             config=config,
             presets=presets,
             indent_overrides=indent_overrides,
@@ -163,6 +181,7 @@ class SubscriptionWithOverridesValidator(SubscriptionLeafValidator, DictFormatte
         self,
         name,
         value,
+        subscription_name: str,
         config: ConfigFile,
         presets: List[str],
         indent_overrides: List[str],
@@ -170,22 +189,13 @@ class SubscriptionWithOverridesValidator(SubscriptionLeafValidator, DictFormatte
         super().__init__(
             name=name,
             value=value,
+            subscription_name=subscription_name,
             config=config,
             presets=presets,
             indent_overrides=indent_overrides,
         )
 
         self._overrides_to_add = dict(self.dict_with_format_strings, **self._overrides_to_add)
-
-    @property
-    def subscription_name(self) -> str:
-        """
-        Returns
-        -------
-        Name of the subscription
-        """
-        # drop the ~ in "~Subscription Name":
-        return super().subscription_name[1:]
 
 
 class SubscriptionValidator(SubscriptionOutput):
@@ -243,6 +253,7 @@ class SubscriptionValidator(SubscriptionOutput):
                     SubscriptionValueValidator(
                         name=obj_name,
                         value=obj,
+                        subscription_name=key,
                         config=config,
                         presets=presets,
                         indent_overrides=indent_overrides,
@@ -257,6 +268,7 @@ class SubscriptionValidator(SubscriptionOutput):
                     SubscriptionListValuesValidator(
                         name=obj_name,
                         value=obj,
+                        subscription_name=key,
                         config=config,
                         presets=presets,
                         indent_overrides=indent_overrides,
@@ -272,6 +284,7 @@ class SubscriptionValidator(SubscriptionOutput):
                         SubscriptionWithOverridesValidator(
                             name=obj_name,
                             value=obj,
+                            subscription_name=key[1:],
                             config=config,
                             presets=presets,
                             indent_overrides=indent_overrides,
@@ -294,6 +307,7 @@ class SubscriptionValidator(SubscriptionOutput):
                         SubscriptionPresetDictValidator(
                             name=obj_name,
                             value=obj,
+                            subscription_name=key,
                             presets=presets,
                             indent_overrides=indent_overrides,
                         )

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -5,7 +5,6 @@ from typing import Dict
 from unittest.mock import patch
 
 import pytest
-from mergedeep import mergedeep
 
 from ytdl_sub.config.config_file import ConfigFile
 from ytdl_sub.plugins.nfo_tags import NfoTagsOptions
@@ -53,6 +52,16 @@ def preset_with_subscription_value(preset_with_file_preset: Dict):
         preset_with_file_preset,
         **{
             "test_value": "is_overwritten",
+        },
+    )
+
+
+@pytest.fixture
+def subscription_with_period_in_name(preset_with_file_preset: Dict):
+    return dict(
+        preset_with_file_preset,
+        **{
+            "Mr. Beast": "is_overwritten",
         },
     )
 
@@ -229,6 +238,18 @@ def test_subscription_overrides_tilda(
 
     assert sub_2_1.get("subscription_name") == "test_2_1"
     assert sub_2_1.get("current_override") == "test_2_1"  # tilda sub takes precedence
+
+
+def test_subscription_with_period_in_name(
+    config_file: ConfigFile,
+    subscription_with_period_in_name: Dict,
+):
+    with mock_load_yaml(preset_dict=subscription_with_period_in_name):
+        subs = Subscription.from_file_path(config=config_file, subscription_path="mocked")
+    assert len(subs) == 2
+
+    assert subs[1].name == "Mr. Beast"
+    assert subs[1].overrides.dict_with_format_strings["subscription_name"] == "Mr. Beast"
 
 
 def test_subscription_file_value_applies_from_config_and_nested_and_indent_variables(


### PR DESCRIPTION
Fixes the bug (https://github.com/jmbannon/ytdl-sub/issues/844) where subscription names would drop periods from them, i.e. `Mr. Beast` would have the name ` Beast`. 

**POTENTIAL BREAKING CHANGE**
If you have a subscription with a period in its name prior to this fix, this change will make it so your download archive is not found since it uses the subscription name in the download archive file path. To fix, simply change the download archive JSON's name to have the actual subscription name, and not the dropped-period one.