### PR TITLE
[FEATURE] `subscription_map` value

### DIFF
--- a/docs/source/config_reference/scripting/override_variables.rst
+++ b/docs/source/config_reference/scripting/override_variables.rst
@@ -21,7 +21,7 @@ For subscriptions in the form of
 
 .. code-block:: yaml
 
-   \ Subscription Name:
+   + Subscription Name:
      Music Videos:
        - "https://url1.com/..."
      Concerts:

--- a/docs/source/config_reference/scripting/override_variables.rst
+++ b/docs/source/config_reference/scripting/override_variables.rst
@@ -15,6 +15,32 @@ For subscriptions in the form of
 ``subscription_indent_1`` and ``subscription_indent_2`` get set to
 ``Indent Value 1`` and ``Indent Value 2``.
 
+subscription_map
+----------------
+For subscriptions in the form of
+
+.. code-block:: yaml
+
+   \ Subscription Name:
+     Music Videos:
+       - "https://url1.com/..."
+     Concerts:
+       - "https://url2.com/..."
+
+Stores all the contents under the subscription name into the override variable
+``subscription_map`` as a Map value. The above example is stored as:
+
+.. code-block:: python
+
+   {
+     "Music Videos": [
+       "https://url1.com/..."
+     ],
+     "Concerts: [
+       "https://url2.com/..."
+     ]
+   }
+
 subscription_name
 -----------------
 Name of the subscription

--- a/src/ytdl_sub/entries/variables/override_variables.py
+++ b/src/ytdl_sub/entries/variables/override_variables.py
@@ -70,7 +70,7 @@ class OverrideVariables:
 
         .. code-block:: yaml
 
-           \\ Subscription Name:
+           + Subscription Name:
              Music Videos:
                - "https://url1.com/..."
              Concerts:

--- a/src/ytdl_sub/entries/variables/override_variables.py
+++ b/src/ytdl_sub/entries/variables/override_variables.py
@@ -63,6 +63,35 @@ class OverrideVariables:
         """
         return f"subscription_value_{index + 1}"
 
+    @staticmethod
+    def subscription_map() -> str:
+        """
+        For subscriptions in the form of
+
+        .. code-block:: yaml
+
+           \\ Subscription Name:
+             Music Videos:
+               - "https://url1.com/..."
+             Concerts:
+               - "https://url2.com/..."
+
+        Stores all the contents under the subscription name into the override variable
+        ``subscription_map`` as a Map value. The above example is stored as:
+
+        .. code-block:: python
+
+           {
+             "Music Videos": [
+               "https://url1.com/..."
+             ],
+             "Concerts: [
+               "https://url2.com/..."
+             ]
+           }
+        """
+        return SUBSCRIPTION_MAP
+
 
 class OverrideHelpers:
     @classmethod

--- a/src/ytdl_sub/subscriptions/subscription_validators.py
+++ b/src/ytdl_sub/subscriptions/subscription_validators.py
@@ -317,7 +317,7 @@ class SubscriptionValidator(SubscriptionOutput):
                 # Subscription defined as
                 # "\Sub Name":
                 #   custom_key: "value"
-                elif key.startswith("\\"):
+                elif key.startswith("+"):
                     self._children.append(
                         SubscriptionMapValidator(
                             name=obj_name,

--- a/src/ytdl_sub/subscriptions/subscription_validators.py
+++ b/src/ytdl_sub/subscriptions/subscription_validators.py
@@ -9,11 +9,14 @@ from typing import final
 
 from ytdl_sub.config.config_file import ConfigFile
 from ytdl_sub.config.overrides import Overrides
+from ytdl_sub.entries.variables.override_variables import SUBSCRIPTION_MAP
 from ytdl_sub.entries.variables.override_variables import SUBSCRIPTION_NAME
 from ytdl_sub.entries.variables.override_variables import SUBSCRIPTION_VALUE
 from ytdl_sub.entries.variables.override_variables import OverrideVariables
+from ytdl_sub.utils.script import ScriptUtils
 from ytdl_sub.validators.string_formatter_validators import DictFormatterValidator
 from ytdl_sub.validators.validators import DictValidator
+from ytdl_sub.validators.validators import LiteralDictValidator
 from ytdl_sub.validators.validators import StringListValidator
 from ytdl_sub.validators.validators import StringValidator
 from ytdl_sub.validators.validators import Validator
@@ -198,6 +201,27 @@ class SubscriptionWithOverridesValidator(SubscriptionLeafValidator, DictFormatte
         self._overrides_to_add = dict(self.dict_with_format_strings, **self._overrides_to_add)
 
 
+class SubscriptionMapValidator(SubscriptionLeafValidator, LiteralDictValidator):
+    def __init__(
+        self,
+        name,
+        value,
+        subscription_name: str,
+        config: ConfigFile,
+        presets: List[str],
+        indent_overrides: List[str],
+    ):
+        super().__init__(
+            name=name,
+            value=value,
+            subscription_name=subscription_name,
+            config=config,
+            presets=presets,
+            indent_overrides=indent_overrides,
+        )
+        self._overrides_to_add = {SUBSCRIPTION_MAP: ScriptUtils.to_script(self.dict)}
+
+
 class SubscriptionValidator(SubscriptionOutput):
     """
     Top-level subscription validator
@@ -284,7 +308,21 @@ class SubscriptionValidator(SubscriptionOutput):
                         SubscriptionWithOverridesValidator(
                             name=obj_name,
                             value=obj,
-                            subscription_name=key[1:],
+                            subscription_name=key[1:].lstrip(),
+                            config=config,
+                            presets=presets,
+                            indent_overrides=indent_overrides,
+                        )
+                    )
+                # Subscription defined as
+                # "\Sub Name":
+                #   custom_key: "value"
+                elif key.startswith("\\"):
+                    self._children.append(
+                        SubscriptionMapValidator(
+                            name=obj_name,
+                            value=obj,
+                            subscription_name=key[1:].lstrip(),
                             config=config,
                             presets=presets,
                             indent_overrides=indent_overrides,

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -172,7 +172,7 @@ def preset_with_subscription_overrides_map(
         preset_with_subscription_value,
         **{
             "parent_preset_2 | parent_preset_1": {
-                "\\ test_2_1": {
+                "+ test_2_1": {
                     "custom_key": "custom_value",
                     "custom_list": [
                         "elem1",

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -156,8 +156,29 @@ def preset_with_subscription_overrides_tilda(
         preset_with_subscription_value,
         **{
             "parent_preset_2 | parent_preset_1": {
-                "~test_2_1": {
+                "~ test_2_1": {
                     "current_override": "test_2_1",
+                }
+            },
+        },
+    )
+
+
+@pytest.fixture
+def preset_with_subscription_overrides_map(
+    preset_with_subscription_value: Dict,
+):
+    return dict(
+        preset_with_subscription_value,
+        **{
+            "parent_preset_2 | parent_preset_1": {
+                "\\ test_2_1": {
+                    "custom_key": "custom_value",
+                    "custom_list": [
+                        "elem1",
+                        "elem2",
+                        "elem3",
+                    ],
                 }
             },
         },
@@ -238,6 +259,27 @@ def test_subscription_overrides_tilda(
 
     assert sub_2_1.get("subscription_name") == "test_2_1"
     assert sub_2_1.get("current_override") == "test_2_1"  # tilda sub takes precedence
+
+
+def test_subscription_overrides_map(
+    config_file: ConfigFile,
+    preset_with_subscription_overrides_map: Dict,
+):
+    with mock_load_yaml(preset_dict=preset_with_subscription_overrides_map):
+        subs = Subscription.from_file_path(config=config_file, subscription_path="mocked")
+    assert len(subs) == 3
+
+    sub_2_1 = [sub for sub in subs if sub.name == "test_2_1"][0].overrides.script
+
+    assert sub_2_1.get("subscription_name").native == "test_2_1"
+    assert sub_2_1.get("subscription_map").native == {
+        "custom_key": "custom_value",
+        "custom_list": [
+            "elem1",
+            "elem2",
+            "elem3",
+        ],
+    }
 
 
 def test_subscription_with_period_in_name(


### PR DESCRIPTION
To be used later for advanced presets. For subscriptions in the form of (+ as prefix)

```
   + Subscription Name:
     Music Videos:
       - "https://url1.com/..."
     Concerts:
       - "https://url2.com/..."
```

Stores all the contents under the subscription name into the override variable
``subscription_map`` as a Map value. The above example is stored as:

```
   {
     "Music Videos": [
       "https://url1.com/..."
     ],
     "Concerts: [
       "https://url2.com/..."
     ]
   }
```

Advanced scripting is needed to dissect this Map variable into a usable preset