### PR TITLE
[FEATURE] `--match` flag to only run subset of subscriptions

### DIFF
--- a/src/ytdl_sub/cli/parsers/main.py
+++ b/src/ytdl_sub/cli/parsers/main.py
@@ -40,6 +40,10 @@ class MainArguments:
         long="--suppress-transaction-log",
         is_positional=True,
     )
+    MATCH = CLIArgument(
+        short="-m",
+        long="--match",
+    )
 
     @classmethod
     def all(cls) -> List[CLIArgument]:
@@ -54,6 +58,7 @@ class MainArguments:
             cls.LOG_LEVEL,
             cls.TRANSACTION_LOG,
             cls.SUPPRESS_TRANSACTION_LOG,
+            cls.MATCH,
         ]
 
     @classmethod
@@ -123,6 +128,16 @@ def _add_shared_arguments(arg_parser: argparse.ArgumentParser, suppress_defaults
         action="store_true",
         help="do not output transaction logs to console or file",
         default=argparse.SUPPRESS if suppress_defaults else False,
+    )
+    arg_parser.add_argument(
+        MainArguments.MATCH.short,
+        MainArguments.MATCH.long,
+        dest="match",
+        nargs="+",
+        action="extend",
+        type=str,
+        help="match subscription names to one or more substrings, and only run those subscriptions",
+        default=argparse.SUPPRESS if suppress_defaults else [],
     )
 
 

--- a/src/ytdl_sub/main.py
+++ b/src/ytdl_sub/main.py
@@ -27,7 +27,7 @@ def main():
     """
     try:
         return_code = _main()
-        Logger.cleanup(cleanup_error_log=return_code == 0)
+        Logger.cleanup(has_error=return_code != 0)
         sys.exit(return_code)
     except Exception as exc:  # pylint: disable=broad-except
         Logger.log_exception(exception=exc)

--- a/tests/unit/cli/test_entrypoint.py
+++ b/tests/unit/cli/test_entrypoint.py
@@ -2,6 +2,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Callable
+from typing import List
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +23,7 @@ from ytdl_sub.utils.exceptions import ExperimentalFeatureNotEnabled
 @pytest.mark.parametrize("dry_run", [True, False])
 @pytest.mark.parametrize("mock_success_output", [True, False])
 @pytest.mark.parametrize("keep_successful_logs", [True, False])
+@pytest.mark.parametrize("match", [[], ["Rick Astley", "Michael Jackson"]])
 def test_subscription_logs_write_to_file(
     persist_logs_directory: str,
     persist_logs_config_factory: Callable,
@@ -30,8 +32,11 @@ def test_subscription_logs_write_to_file(
     dry_run: bool,
     mock_success_output: bool,
     keep_successful_logs: bool,
+    match: List[str],
 ):
-    subscripton_names = ["Rick Astley", "Michael Jackson", "Eric Clapton"]
+    subscription_names = ["Rick Astley", "Michael Jackson", "Eric Clapton"]
+    if match:
+        subscription_names = match
     num_runs = 2
 
     config = persist_logs_config_factory(keep_successful_logs=keep_successful_logs)
@@ -47,6 +52,7 @@ def test_subscription_logs_write_to_file(
             _download_subscriptions_from_yaml_files(
                 config=config,
                 subscription_paths=subscription_paths,
+                subscription_matches=match,
                 update_with_info_json=False,
                 dry_run=dry_run,
             )
@@ -61,8 +67,8 @@ def test_subscription_logs_write_to_file(
         return
     # If not success, expect 2 log files for both sub errors
     elif not mock_success_output:
-        assert len(log_directory_files) == (num_runs * len(subscripton_names))
-        for log_path, subscription_name in zip(log_directory_files, subscripton_names):
+        assert len(log_directory_files) == (num_runs * len(subscription_names))
+        for log_path, subscription_name in zip(log_directory_files, subscription_names):
             subscription_log_file_name = subscription_name.lower().replace(" ", "_")
 
             assert bool(re.match(rf"\d\.{subscription_log_file_name}\.error\.log", log_path.name))
@@ -74,9 +80,9 @@ def test_subscription_logs_write_to_file(
                 )
     # If success and success logging, expect 3 log files
     else:
-        assert len(log_directory_files) == (num_runs * len(subscripton_names))
+        assert len(log_directory_files) == (num_runs * len(subscription_names))
         for log_file_path, subscription_name in zip(
-            log_directory_files, subscripton_names * num_runs
+            log_directory_files, subscription_names * num_runs
         ):
             subscription_log_file_name = subscription_name.lower().replace(" ", "_")
 

--- a/tests/unit/cli/test_entrypoint.py
+++ b/tests/unit/cli/test_entrypoint.py
@@ -23,7 +23,7 @@ from ytdl_sub.utils.exceptions import ExperimentalFeatureNotEnabled
 @pytest.mark.parametrize("dry_run", [True, False])
 @pytest.mark.parametrize("mock_success_output", [True, False])
 @pytest.mark.parametrize("keep_successful_logs", [True, False])
-@pytest.mark.parametrize("match", [[], ["Rick Astley", "Michael Jackson"]])
+@pytest.mark.parametrize("match", [[], ["Rick", "Michael"]])
 def test_subscription_logs_write_to_file(
     persist_logs_directory: str,
     persist_logs_config_factory: Callable,
@@ -36,7 +36,7 @@ def test_subscription_logs_write_to_file(
 ):
     subscription_names = ["Rick Astley", "Michael Jackson", "Eric Clapton"]
     if match:
-        subscription_names = match
+        subscription_names = ["Rick Astley", "Michael Jackson"]
     num_runs = 2
 
     config = persist_logs_config_factory(keep_successful_logs=keep_successful_logs)

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -107,6 +107,58 @@ def test_args_after_sub_work(mock_sys_exit, tv_show_config_path):
         assert mock_sub.call_count == 1
         assert mock_sub.call_args.kwargs["subscription_paths"] == ["subscriptions.yaml"]
         assert mock_sub.call_args.kwargs["config"]._name == tv_show_config_path
+        assert mock_sub.call_args.kwargs["subscription_matches"] == []
+        assert Logger._LOGGER_LEVEL == LoggerLevels.VERBOSE
+
+
+def test_sub_match_arguments_before(mock_sys_exit, tv_show_config_path):
+    with mock_sys_exit(expected_exit_code=0), patch.object(
+        sys,
+        "argv",
+        [
+            "ytdl-sub",
+            "--match",
+            "testA",
+            "testB",
+            "-c",
+            tv_show_config_path,
+            "sub",
+            "--log-level",
+            "verbose",
+        ],
+    ), patch("ytdl_sub.cli.entrypoint._download_subscriptions_from_yaml_files") as mock_sub:
+        main()
+
+        assert mock_sub.call_count == 1
+        assert mock_sub.call_args.kwargs["subscription_paths"] == ["subscriptions.yaml"]
+        assert mock_sub.call_args.kwargs["config"]._name == tv_show_config_path
+        assert mock_sub.call_args.kwargs["subscription_matches"] == ["testA", "testB"]
+        assert Logger._LOGGER_LEVEL == LoggerLevels.VERBOSE
+
+
+def test_sub_match_arguments_after_many(mock_sys_exit, tv_show_config_path):
+    with mock_sys_exit(expected_exit_code=0), patch.object(
+        sys,
+        "argv",
+        [
+            "ytdl-sub",
+            "-c",
+            tv_show_config_path,
+            "sub",
+            "--log-level",
+            "verbose",
+            "--match",
+            "testA",
+            "--match",
+            "testB",
+        ],
+    ), patch("ytdl_sub.cli.entrypoint._download_subscriptions_from_yaml_files") as mock_sub:
+        main()
+
+        assert mock_sub.call_count == 1
+        assert mock_sub.call_args.kwargs["subscription_paths"] == ["subscriptions.yaml"]
+        assert mock_sub.call_args.kwargs["config"]._name == tv_show_config_path
+        assert mock_sub.call_args.kwargs["subscription_matches"] == ["testA", "testB"]
         assert Logger._LOGGER_LEVEL == LoggerLevels.VERBOSE
 
 

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -47,8 +47,8 @@ def test_main_exit_code(mock_sys_exit, return_code: int):
         main()
 
         assert mock_logger_cleanup.call_count == 1
-        assert mock_logger_cleanup.call_args.kwargs["cleanup_error_log"] == (
-            True if return_code == 0 else False
+        assert mock_logger_cleanup.call_args.kwargs["has_error"] == (
+            True if return_code != 0 else False
         )
 
 

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -111,8 +111,8 @@ class TestLogger:
         Logger.cleanup()
         assert not os.path.isfile(Logger._DEBUG_LOGGER_FILE.name)
 
-    @pytest.mark.parametrize("clean_error_log", [True, False])
-    def test_logger_can_be_cleaned_during_execution(self, clean_error_log: bool):
+    @pytest.mark.parametrize("has_error", [True, False])
+    def test_logger_can_be_cleaned_during_execution(self, has_error: bool):
         Logger._LOGGER_LEVEL = LoggerLevels.INFO
         logger = Logger.get(name="name_test")
 
@@ -133,11 +133,11 @@ class TestLogger:
             except ValueError as exc:
                 Logger.log_exception(exception=exc)
 
-            Logger.cleanup(cleanup_error_log=clean_error_log)
+            Logger.cleanup(has_error=has_error)
             assert not os.path.isfile(Logger.debug_log_filename())
 
-            assert clean_error_log == (not os.path.isfile(Logger.error_log_filename()))
-            if not clean_error_log:
+            assert not has_error == (not os.path.isfile(Logger.error_log_filename()))
+            if has_error:
                 with open(Logger.error_log_filename(), mode="r", encoding="utf-8") as err_file:
                     err_logs = err_file.readlines()
                     expected = [


### PR DESCRIPTION
Implements https://github.com/jmbannon/ytdl-sub/issues/880
and maybe fixes https://github.com/jmbannon/ytdl-sub/issues/827

Can now do `ytdl-sub sub --match SubA SubB` or `ytdl-sub sub --match SubA --match SubB`, which will only run subscriptions that contain `SubA` or `SubB` in their names