### PR TITLE
[BACKEND] Try to fetch source metadata from uploader_url

### DIFF
--- a/src/ytdl_sub/downloaders/url/downloader.py
+++ b/src/ytdl_sub/downloaders/url/downloader.py
@@ -404,7 +404,6 @@ class MultiUrlDownloader(SourcePlugin[MultiUrlValidator]):
             )
 
         parents = EntryParent.from_entry_dicts(
-            url=url,
             entry_dicts=entry_dicts,
             working_directory=self.working_directory,
             include_sibling_metadata=include_sibling_metadata,

--- a/src/ytdl_sub/downloaders/url/downloader.py
+++ b/src/ytdl_sub/downloaders/url/downloader.py
@@ -404,6 +404,7 @@ class MultiUrlDownloader(SourcePlugin[MultiUrlValidator]):
             )
 
         parents = EntryParent.from_entry_dicts(
+            url=url,
             entry_dicts=entry_dicts,
             working_directory=self.working_directory,
             include_sibling_metadata=include_sibling_metadata,

--- a/src/ytdl_sub/downloaders/ytdlp.py
+++ b/src/ytdl_sub/downloaders/ytdlp.py
@@ -238,15 +238,17 @@ class YTDLP:
             cls.logger.info("MaxDownloadsReached, stopping additional downloads.")
 
         # For YouTube playlists in particular, channel metadata is not fetched. Attempt to get
-        # channel metadata via grabbing uploader_url info json
+        # channel metadata via grabbing uploader_url info json a max of 3 times
+        current_iter = 0
         url = kwargs.get("url")
         uploader_url = parent_dict.get("uploader_url")
-        while uploader_url and url != uploader_url:
+        while current_iter < 3 and uploader_url and url != uploader_url:
             cls.logger.debug("Attempting to get parent metadata from URL %s", uploader_url)
             parent_dict = cls.extract_info(
                 ytdl_options_overrides=ytdl_options_overrides | {"playlist_items": "0:0"},
                 url=uploader_url,
             )
+            current_iter += 1
             url = uploader_url
             uploader_url = parent_dict.get("uploader_url")
 

--- a/src/ytdl_sub/downloaders/ytdlp.py
+++ b/src/ytdl_sub/downloaders/ytdlp.py
@@ -216,11 +216,14 @@ class YTDLP:
         **kwargs
             arguments passed directory to YoutubeDL extract_info
         """
+        parent_dict: Dict = {}
         try:
             with cls._listen_and_log_downloaded_info_json(
                 working_directory=working_directory, log_prefix=log_prefix_on_info_json_dl
             ):
-                _ = cls.extract_info(ytdl_options_overrides=ytdl_options_overrides, **kwargs)
+                parent_dict = cls.extract_info(
+                    ytdl_options_overrides=ytdl_options_overrides, **kwargs
+                )
         except RejectedVideoReached:
             cls.logger.debug(
                 "RejectedVideoReached, stopping additional downloads "
@@ -233,5 +236,18 @@ class YTDLP:
             )
         except MaxDownloadsReached:
             cls.logger.info("MaxDownloadsReached, stopping additional downloads.")
+
+        # For YouTube playlists in particular, channel metadata is not fetched. Attempt to get
+        # channel metadata via grabbing uploader_url info json
+        url = kwargs.get("url")
+        uploader_url = parent_dict.get("uploader_url")
+        while uploader_url and url != uploader_url:
+            cls.logger.debug("Attempting to get parent metadata from URL %s", uploader_url)
+            parent_dict = cls.extract_info(
+                ytdl_options_overrides=ytdl_options_overrides | {"playlist_items": "0:0"},
+                url=uploader_url,
+            )
+            url = uploader_url
+            uploader_url = parent_dict.get("uploader_url")
 
         return cls._get_entry_dicts_from_info_json_files(working_directory=working_directory)

--- a/src/ytdl_sub/entries/entry_parent.py
+++ b/src/ytdl_sub/entries/entry_parent.py
@@ -144,9 +144,7 @@ class EntryParent(BaseEntry):
         return self.uid == playlist_id or any(item in child for child in self.parent_children())
 
     @classmethod
-    def _get_disconnected_root_parent(
-        cls, url: str, parents: List["EntryParent"]
-    ) -> Optional["EntryParent"]:
+    def _get_disconnected_root_parent(cls, parents: List["EntryParent"]) -> Optional["EntryParent"]:
         """
         Sometimes the root-level parent is disconnected via playlist_ids Find it if it exists.
         """
@@ -200,7 +198,7 @@ class EntryParent(BaseEntry):
             return []
 
         # If a disconnected root parent exists, connect it here
-        if (root_parent := cls._get_disconnected_root_parent(url, parents)) is not None:
+        if (root_parent := cls._get_disconnected_root_parent(parents)) is not None:
             parents.remove(root_parent)
             root_parent._parent_children = parents
             parents = [root_parent]

--- a/src/ytdl_sub/entries/entry_parent.py
+++ b/src/ytdl_sub/entries/entry_parent.py
@@ -151,15 +151,10 @@ class EntryParent(BaseEntry):
         Sometimes the root-level parent is disconnected via playlist_ids Find it if it exists.
         """
 
-        def _url_matches(parent: "EntryParent"):
-            return parent.webpage_url in url or url in parent.webpage_url
-
         def _uid_is_uploader_id(parent: "EntryParent"):
             return parent.uid == parent.uploader_id
 
-        top_level_parents = [
-            parent for parent in parents if parent.num_children() == 0 and _url_matches(parent)
-        ]
+        top_level_parents = [parent for parent in parents if parent.num_children() == 0]
 
         # If more than 1 parent exists, assume the uploader_id is the root parent
         if len(top_level_parents) > 1:

--- a/src/ytdl_sub/entries/entry_parent.py
+++ b/src/ytdl_sub/entries/entry_parent.py
@@ -178,7 +178,6 @@ class EntryParent(BaseEntry):
     @classmethod
     def from_entry_dicts(
         cls,
-        url: str,
         entry_dicts: List[Dict],
         working_directory: str,
         include_sibling_metadata: bool,


### PR DESCRIPTION
Makes it possible to fix https://github.com/jmbannon/ytdl-sub/issues/756

In the case that uploader_url does not equal the input url, keep trying to fetch uploader_url to get all possible metadata that yt-dlp does not provide in a single API call