### PR TITLE
[BUGFIX] Fix usage of `chapter_title_sanitized`

### DIFF
--- a/src/ytdl_sub/plugins/split_by_chapters.py
+++ b/src/ytdl_sub/plugins/split_by_chapters.py
@@ -89,7 +89,6 @@ class SplitByChaptersOptions(OptionsDictValidator):
         return {
             PluginOperation.MODIFY_ENTRY: {
                 "chapter_title",
-                "chapter_title_sanitized",
                 "chapter_index",
                 "chapter_index_padded",
                 "chapter_count",


### PR DESCRIPTION
Usage of `chapter_title_sanitized` would sometimes result in an error. This should hopefully fix it