### PR TITLE
Fixing daterange explanation

### DIFF
--- a/docs/source/config_reference/plugins.rst
+++ b/docs/source/config_reference/plugins.rst
@@ -156,7 +156,7 @@ granularity possible.
 
 :expected type: Optional[OverridesFormatter]
 :description:
-  Only download videos before this datetime.
+  Only download videos after this datetime.
 
 
 ``before``


### PR DESCRIPTION
Fixing a small mistake daterange.after explanation