### PR TITLE
[BUGFIX] Use epoch_date if upload_date is missing

### DIFF
--- a/src/ytdl_sub/entries/script/variable_definitions.py
+++ b/src/ytdl_sub/entries/script/variable_definitions.py
@@ -394,7 +394,9 @@ class UploadDateVariableDefinitions(ABC):
         :description:
           The entry’s uploaded date, in YYYYMMDD format. If not present, return today’s date.
         """
-        return StringDateMetadataVariable.from_entry(metadata_key="upload_date").as_date_variable()
+        return StringDateMetadataVariable.from_entry(
+            metadata_key="upload_date", default=self.epoch_date
+        ).as_date_variable()
 
     @cached_property
     def upload_year(self: "VariableDefinitions") -> IntegerVariable:


### PR DESCRIPTION
Fixes https://github.com/jmbannon/ytdl-sub/issues/912

If a required variable (like uid) is missing, ytdl-sub will error. This bugfix prevents sites that do not provide an upload date from erroring.