### PR TITLE
[FEATURE] Simplify TV Show Collection Preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,8 @@ __preset__:
     cookiefile: "/config/cookie.txt" 
 
 ###################################################################
-# Subscriptions nested under this will use the
-# `Plex TV Show by Date` preset.
-#
-# Can choose between:
-#   - Plex TV Show by Date:
-#   - Jellyfin TV Show by Date:
-#   - Kodi TV Show by Date:
+# TV Show Presets. Can replace Plex with Plex/Jellyfin/Kodi
+
 Plex TV Show by Date:
 
   # Sets genre tag to "Documentaries"
@@ -101,9 +96,18 @@ Plex TV Show by Date:
   = News | Only Recent:
     "BBC News": "https://www.youtube.com/@BBCNews"
 
+Plex TV Show Collection:
+  = Music:
+    # Prefix with ~ to set specific override variables
+    "~Beyond the Guitar":
+      s01_name: "Videos"
+      s01_url: "https://www.youtube.com/c/BeyondTheGuitar"
+      s02_name: "Covers"
+      s02_url: "https://www.youtube.com/playlist?list=PLE62gWlWZk5NWVAVuf0Lm9jdv_-_KXs0W"
+
 ###################################################################
-# Subscriptions nested under these will use the various prebuilt
-# music presets
+# Music Presets. Can replace Plex with Plex/Jellyfin/Kodi
+
 YouTube Releases:
   = Jazz:  # Sets genre tag to "Jazz"
     "Thelonious Monk": "https://www.youtube.com/@theloniousmonk3870/releases"
@@ -124,10 +128,7 @@ Bandcamp:
     "Emily Hopkins": "https://emilyharpist.bandcamp.com/"
 
 ###################################################################
-# Can choose between:
-#   - Plex Music Videos:
-#   - Jellyfin Music Videos:
-#   - Kodi Music Videos:
+# Music Video Presets
 "Plex Music Videos":
   = Pop:  # Sets genre tag to "Pop"
     "Rick Astley": "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"

--- a/docs/source/config_reference/subscriptions_yaml.rst
+++ b/docs/source/config_reference/subscriptions_yaml.rst
@@ -19,9 +19,7 @@ Below is an example that downloads a YouTube playlist:
 
   presets:
     playlist_preset_ex:
-      download:
-        download_strategy: "url"
-        url: "{url}"
+      download: "{url}"
       output_options:
         output_directory: "{output_directory}/{playlist_name}"
         file_name: "{playlist_name}.{title}.{ext}"

--- a/docs/source/prebuilt_presets/tv_shows.rst
+++ b/docs/source/prebuilt_presets/tv_shows.rst
@@ -38,16 +38,33 @@ TV Show by Date
 
 TV Show by Date will organize something like a YouTube channel or playlist into a tv show, where seasons and episodes are organized using upload date.
 
-Plug and Play Presets
-~~~~~~~~~~~~~~~~~~~~~
-
-You can use any of these presets in your ``subscriptions.yaml`` as a "One size fits all" solution- they should set all appropriate values. These will organize seasons by year and episodes by month, then day.
-
-Must define ``tv_show_directory``
+Example
+~~~~~~~
+Must define ``tv_show_directory``. Available presets:
 
 * ``"Kodi TV Show by Date"``
 * ``"Jellyfin TV Show by Date"``
 * ``"Plex TV Show by Date"``
+
+.. code-block:: yaml
+
+   __preset__:
+     overrides:
+       tv_show_directory: "/tv_shows"
+
+   Plex TV Show by Date:
+
+     # Sets genre tag to "Documentaries"
+     = Documentaries:
+       "NOVA PBS": "https://www.youtube.com/@novapbs"
+       "National Geographic": "https://www.youtube.com/@NatGeo"
+       "Cosmos - What If": "https://www.youtube.com/playlist?list=PLZdXRHYAVxTJno6oFF9nLGuwXNGYHmE8U"
+
+     # Sets genre tag to "Kids", "TV-Y" for content rating
+     = Kids | = TV-Y:
+       "Jake Trains": "https://www.youtube.com/@JakeTrains"
+       "Kids Toys Play": "https://www.youtube.com/@KidsToysPlayChannel"
+
 
 Advanced Usage
 ~~~~~~~~~~~~~~
@@ -105,9 +122,9 @@ You can also choose to combine multiple URLs into one show. This will result in 
 TV Show Collection
 ------------------
 
-TV Show Collections are made up of multiple URLs, where each URL is a season.
-If a video belongs to multiple URLs (i.e. a channel and a channel's playlist),
-it will resolve to the bottom-most season, as defined in the subscription.
+TV Show Collections set each URL as its own season. If a video belongs to multiple URLs
+(i.e. a channel and a channel's playlist), the video will only download once and reside in
+the higher-numbered season.
 
 Two main use cases of a collection are:
    1. Organize a YouTube channel TV show where Season 1 contains any video
@@ -116,15 +133,41 @@ Two main use cases of a collection are:
    2. Organize one or more YouTube channels/playlists, where each season
       represents a separate channel/playlist.
 
-Player Presets
+Example
+~~~~~~~
+Must define ``tv_show_directory``. Available presets:
+
+* ``"Kodi TV Collection"``
+* ``"Jellyfin TV Collection"``
+* ``"Plex TV Collection"``
+
+.. code-block:: yaml
+
+   __preset__:
+     overrides:
+       tv_show_directory: "/tv_shows"
+
+   Plex TV Show Collection:
+     = Music:
+       # Prefix with ~ to set specific override variables
+       "~Beyond the Guitar":
+         s01_name: "Videos"
+         s01_url: "https://www.youtube.com/c/BeyondTheGuitar"
+         s02_name: "Covers"
+         s02_url: "https://www.youtube.com/playlist?list=PLE62gWlWZk5NWVAVuf0Lm9jdv_-_KXs0W"
+
+Advanced Usage
 ~~~~~~~~~~~~~~
+
+If you prefer a different organization method, you can instead apply multiple presets to your subscriptions.
+
+You will need a base of one of the below:
 
 * ``kodi_tv_show_collection``
 * ``jellyfin_tv_show_collection``
 * ``plex_tv_show_collection``
 
-Episode Formatting Presets
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+And then add one of these:
 
 * ``season_by_collection__episode_by_year_month_day``
 * ``season_by_collection__episode_by_year_month_day_reversed``
@@ -146,6 +189,8 @@ with the following override variables:
     preset:
       - "jellyfin_tv_show_collection"
       - "season_by_collection__episode_by_year_month_day_reversed"
+      - "collection_season_1"
+      - "collection_season_2"
     overrides:
       # required
       tv_show_name: "Rick A"
@@ -154,7 +199,10 @@ with the following override variables:
       collection_season_1_name: "All Videos"
       collection_season_2_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"
       collection_season_2_name: "Official Music Videos"
-      # can be modified from their default value
-      # tv_show_genre: "ytdl-sub"
-      # episode_title: "{upload_date_standardized} - {title}"
-      # episode_description: "{webpage_url}"
+
+  Jellyfin TV Show Collection:
+    "~Rick A":
+      s01_name: "All Videos"
+      s01_url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
+      s02_name: "Official Music Videos"
+      s02_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"

--- a/docs/source/prebuilt_presets/tv_shows.rst
+++ b/docs/source/prebuilt_presets/tv_shows.rst
@@ -65,6 +65,11 @@ Must define ``tv_show_directory``. Available presets:
        "Jake Trains": "https://www.youtube.com/@JakeTrains"
        "Kids Toys Play": "https://www.youtube.com/@KidsToysPlayChannel"
 
+     = Music:
+       # TV show subscriptions can support multiple urls and store in the same TV Show
+       "Rick Beato":
+         - "https://www.youtube.com/@RickBeato"
+         - "https://www.youtube.com/@rickbeato240"
 
 Advanced Usage
 ~~~~~~~~~~~~~~
@@ -88,36 +93,6 @@ And then add one of these:
   
   * Episodes are numbered by the download order. NOTE that this is fetched using the length of the download archive. Do not use if you intend to remove old videos.
 
-An example of a subscription that will be played on Kodi, organized by year with the most recent episode at the top (having a lower episode number), with a genre of "Pop":
-
-.. code-block:: yaml
-  :caption: subscriptions.yaml
-
-  __preset__:
-    overrides:
-      tv_show_directory: "/tv_shows"
-
-  kodi_tv_show_by_date:
-    season_by_year_episode_by_month_day_reversed:
-      = Pop:
-        "Rick A": "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
-
-You can also choose to combine multiple URLs into one show. This will result in your videos being downloaded to the same folder, and the episode numbers being shared between them (so you won't have two episode 10's, for example). Note that you may :ytdl-sub-gh:`experience issues <issues/833>` if you use more than 20 URLs at this time.
-
-.. code-block:: yaml
-  :caption: subscriptions.yaml
-
-  __preset__:
-    overrides:
-      tv_show_directory: "/tv_shows"
-
-  kodi_tv_show_by_date:
-    season_by_year_episode_by_month_day_reversed:
-      = Pop:
-        "~Rick A": 
-          url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
-          url2: "https://www.youtube.com/@just.rick_6"
-
 
 TV Show Collection
 ------------------
@@ -137,9 +112,9 @@ Example
 ~~~~~~~
 Must define ``tv_show_directory``. Available presets:
 
-* ``"Kodi TV Collection"``
-* ``"Jellyfin TV Collection"``
-* ``"Plex TV Collection"``
+* ``"Kodi TV Show Collection"``
+* ``"Jellyfin TV Show Collection"``
+* ``"Plex TV Show Collection"``
 
 .. code-block:: yaml
 
@@ -175,34 +150,3 @@ And then add one of these:
   
   * Only use playlist_index episode formatting for playlists that will be fully downloaded once and never again. Otherwise, indices can change.
 * ``season_by_collection__episode_by_playlist_index_reversed``
-
-
-Example
-~~~~~~~
-
-A preset/subscription requires specifying a player and episode formatting
-with the following override variables:
-
-.. code-block:: yaml
-
-  rick_a_tv_show_collection:
-    preset:
-      - "jellyfin_tv_show_collection"
-      - "season_by_collection__episode_by_year_month_day_reversed"
-      - "collection_season_1"
-      - "collection_season_2"
-    overrides:
-      # required
-      tv_show_name: "Rick A"
-      tv_show_directory: "/path/to/youtube_shows"
-      collection_season_1_url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
-      collection_season_1_name: "All Videos"
-      collection_season_2_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"
-      collection_season_2_name: "Official Music Videos"
-
-  Jellyfin TV Show Collection:
-    "~Rick A":
-      s01_name: "All Videos"
-      s01_url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
-      s02_name: "Official Music Videos"
-      s02_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"

--- a/docs/source/prebuilt_presets/tv_shows.rst
+++ b/docs/source/prebuilt_presets/tv_shows.rst
@@ -133,21 +133,12 @@ Episode Formatting Presets
   * Only use playlist_index episode formatting for playlists that will be fully downloaded once and never again. Otherwise, indices can change.
 * ``season_by_collection__episode_by_playlist_index_reversed``
 
-Season Presets
-~~~~~~~~~~~~~~
-
-* ``collection_season_1``
-* ``collection_season_2``
-* ``collection_season_3``
-* ``collection_season_4``
-* ``...``
-* ``collection_season_40``
 
 Example
 ~~~~~~~
 
-A preset/subscription requires specifying a player, episode formatting, and
-one or more season presets, with the following override variables:
+A preset/subscription requires specifying a player and episode formatting
+with the following override variables:
 
 .. code-block:: yaml
 
@@ -155,8 +146,6 @@ one or more season presets, with the following override variables:
     preset:
       - "jellyfin_tv_show_collection"
       - "season_by_collection__episode_by_year_month_day_reversed"
-      - "collection_season_1"
-      - "collection_season_2"
     overrides:
       # required
       tv_show_name: "Rick A"

--- a/examples/tv_show_subscriptions.yaml
+++ b/examples/tv_show_subscriptions.yaml
@@ -56,3 +56,20 @@ Plex TV Show by Date:
   # Set "News" for genre, use `Only Recent` preset to only store videos uploaded recently
   = News | Only Recent:
     "BBC News": "https://www.youtube.com/@BBCNews"
+
+# Sets URLs to be explicit seasons. If a video resides in multiple URLs, it will
+# only appear once in the higher-numbered season. This is how you can separate a channel's
+# videos and playlists you are interested in.
+#
+# Choose the player you intend to use by setting the top-level key to be either:
+#   - Plex TV Show Collection:
+#   - Jellyfin TV Show Collection:
+#   - Kodi TV Show Collection:
+Plex TV Show Collection:
+  = Music:
+    "~Beyond the Guitar":
+      s01_name: "Videos"
+      s01_url: "https://www.youtube.com/c/BeyondTheGuitar"
+
+      s02_name: "Music Videos"
+      s02_url: "https://www.youtube.com/playlist?list=PLE62gWlWZk5NWVAVuf0Lm9jdv_-_KXs0W"

--- a/src/ytdl_sub/prebuilt_presets/music/other_websites.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music/other_websites.yaml
@@ -5,7 +5,6 @@ presets:
 
     # Download using the multi_url strategy
     download:
-      download_strategy: "multi_url"
       urls:
         # The first URL will be all the artist's tracks.
         # Treat these as singles - an album with a single track

--- a/src/ytdl_sub/prebuilt_presets/tv_show/__init__.py
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/__init__.py
@@ -52,6 +52,8 @@ class TvShowCollectionEpisodeFormattingPresets(PrebuiltPresets):
 
 
 class TvShowCollectionSeasonPresets(PrebuiltPresets):
+    """Now Deprecated"""
+
     preset_names = {
         "collection_season_1",
         "collection_season_2",

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show.yaml
@@ -40,14 +40,6 @@ presets:
 
 ####################################################################################################
 
-  # TV show from a collection. Must specify additional `tv_show_collection_season` presets in
-  # addition. Each season sets its own `collection_season_number/_padded`
-  _tv_show_collection:
-    overrides:
-      collection_season_number_padded: "{ %pad_zero(%int(collection_season_number), 2) }"
-      season_number: "{collection_season_number}"
-      season_number_padded: "{collection_season_number_padded}"
-
   _episode_video_tags:
     video_tags:
       show: "{tv_show_name}"

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
@@ -15,10 +15,7 @@ presets:
       - "_plex_tv_show"
       - "_tv_show_collection"
 
-####################################################################################################
-# SEASON PRESETS
-
-  collection_season_1:
+  _tv_show_collection:
     download:
       - url: "{collection_season_1_url}"
         variables:
@@ -38,16 +35,6 @@ presets:
             uid: "avatar_uncropped"
           - name: "{tv_show_fanart_file_name}"
             uid: "banner_uncropped"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_1_name}"
-            attributes:
-              number: "1"
-
-  collection_season_2:
-    download:
       - url: "{collection_season_2_url}"
         variables:
           collection_season_number: "2"
@@ -55,16 +42,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_2_name}"
-            attributes:
-              number: "2"
-
-  collection_season_3:
-    download:
       - url: "{collection_season_3_url}"
         variables:
           collection_season_number: "3"
@@ -72,16 +49,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_3_name}"
-            attributes:
-              number: "3"
-
-  collection_season_4:
-    download:
       - url: "{collection_season_4_url}"
         variables:
           collection_season_number: "4"
@@ -89,16 +56,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_4_name}"
-            attributes:
-              number: "4"
-
-  collection_season_5:
-    download:
       - url: "{collection_season_5_url}"
         variables:
           collection_season_number: "5"
@@ -106,16 +63,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_5_name}"
-            attributes:
-              number: "5"
-
-  collection_season_6:
-    download:
       - url: "{collection_season_6_url}"
         variables:
           collection_season_number: "6"
@@ -123,16 +70,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_6_name}"
-            attributes:
-              number: "6"
-
-  collection_season_7:
-    download:
       - url: "{collection_season_7_url}"
         variables:
           collection_season_number: "7"
@@ -140,16 +77,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_7_name}"
-            attributes:
-              number: "7"
-
-  collection_season_8:
-    download:
       - url: "{collection_season_8_url}"
         variables:
           collection_season_number: "8"
@@ -157,16 +84,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_8_name}"
-            attributes:
-              number: "8"
-
-  collection_season_9:
-    download:
       - url: "{collection_season_9_url}"
         variables:
           collection_season_number: "9"
@@ -174,16 +91,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_9_name}"
-            attributes:
-              number: "9"
-
-  collection_season_10:
-    download:
       - url: "{collection_season_10_url}"
         variables:
           collection_season_number: "10"
@@ -191,16 +98,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_10_name}"
-            attributes:
-              number: "10"
-
-  collection_season_11:
-    download:
       - url: "{collection_season_11_url}"
         variables:
           collection_season_number: "11"
@@ -208,16 +105,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_11_name}"
-            attributes:
-              number: "11"
-
-  collection_season_12:
-    download:
       - url: "{collection_season_12_url}"
         variables:
           collection_season_number: "12"
@@ -225,16 +112,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_12_name}"
-            attributes:
-              number: "12"
-
-  collection_season_13:
-    download:
       - url: "{collection_season_13_url}"
         variables:
           collection_season_number: "13"
@@ -242,16 +119,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_13_name}"
-            attributes:
-              number: "13"
-
-  collection_season_14:
-    download:
       - url: "{collection_season_14_url}"
         variables:
           collection_season_number: "14"
@@ -259,16 +126,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_14_name}"
-            attributes:
-              number: "14"
-
-  collection_season_15:
-    download:
       - url: "{collection_season_15_url}"
         variables:
           collection_season_number: "15"
@@ -276,16 +133,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_15_name}"
-            attributes:
-              number: "15"
-
-  collection_season_16:
-    download:
       - url: "{collection_season_16_url}"
         variables:
           collection_season_number: "16"
@@ -293,16 +140,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_16_name}"
-            attributes:
-              number: "16"
-
-  collection_season_17:
-    download:
       - url: "{collection_season_17_url}"
         variables:
           collection_season_number: "17"
@@ -310,16 +147,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_17_name}"
-            attributes:
-              number: "17"
-
-  collection_season_18:
-    download:
       - url: "{collection_season_18_url}"
         variables:
           collection_season_number: "18"
@@ -327,16 +154,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_18_name}"
-            attributes:
-              number: "18"
-
-  collection_season_19:
-    download:
       - url: "{collection_season_19_url}"
         variables:
           collection_season_number: "19"
@@ -344,16 +161,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_19_name}"
-            attributes:
-              number: "19"
-
-  collection_season_20:
-    download:
       - url: "{collection_season_20_url}"
         variables:
           collection_season_number: "20"
@@ -361,16 +168,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_20_name}"
-            attributes:
-              number: "20"
-
-  collection_season_21:
-    download:
       - url: "{collection_season_21_url}"
         variables:
           collection_season_number: "21"
@@ -378,16 +175,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_21_name}"
-            attributes:
-              number: "21"
-
-  collection_season_22:
-    download:
       - url: "{collection_season_22_url}"
         variables:
           collection_season_number: "22"
@@ -395,16 +182,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_22_name}"
-            attributes:
-              number: "22"
-
-  collection_season_23:
-    download:
       - url: "{collection_season_23_url}"
         variables:
           collection_season_number: "23"
@@ -412,16 +189,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_23_name}"
-            attributes:
-              number: "23"
-
-  collection_season_24:
-    download:
       - url: "{collection_season_24_url}"
         variables:
           collection_season_number: "24"
@@ -429,16 +196,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_24_name}"
-            attributes:
-              number: "24"
-
-  collection_season_25:
-    download:
       - url: "{collection_season_25_url}"
         variables:
           collection_season_number: "25"
@@ -446,16 +203,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_25_name}"
-            attributes:
-              number: "25"
-
-  collection_season_26:
-    download:
       - url: "{collection_season_26_url}"
         variables:
           collection_season_number: "26"
@@ -463,16 +210,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_26_name}"
-            attributes:
-              number: "26"
-
-  collection_season_27:
-    download:
       - url: "{collection_season_27_url}"
         variables:
           collection_season_number: "27"
@@ -480,16 +217,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_27_name}"
-            attributes:
-              number: "27"
-
-  collection_season_28:
-    download:
       - url: "{collection_season_28_url}"
         variables:
           collection_season_number: "28"
@@ -497,16 +224,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_28_name}"
-            attributes:
-              number: "28"
-
-  collection_season_29:
-    download:
       - url: "{collection_season_29_url}"
         variables:
           collection_season_number: "29"
@@ -514,16 +231,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_29_name}"
-            attributes:
-              number: "29"
-
-  collection_season_30:
-    download:
       - url: "{collection_season_30_url}"
         variables:
           collection_season_number: "30"
@@ -531,16 +238,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_30_name}"
-            attributes:
-              number: "30"
-
-  collection_season_31:
-    download:
       - url: "{collection_season_31_url}"
         variables:
           collection_season_number: "31"
@@ -548,16 +245,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_31_name}"
-            attributes:
-              number: "31"
-
-  collection_season_32:
-    download:
       - url: "{collection_season_32_url}"
         variables:
           collection_season_number: "32"
@@ -565,16 +252,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_32_name}"
-            attributes:
-              number: "32"
-
-  collection_season_33:
-    download:
       - url: "{collection_season_33_url}"
         variables:
           collection_season_number: "33"
@@ -582,16 +259,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_33_name}"
-            attributes:
-              number: "33"
-
-  collection_season_34:
-    download:
       - url: "{collection_season_34_url}"
         variables:
           collection_season_number: "34"
@@ -599,16 +266,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_34_name}"
-            attributes:
-              number: "34"
-
-  collection_season_35:
-    download:
       - url: "{collection_season_35_url}"
         variables:
           collection_season_number: "35"
@@ -616,16 +273,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_35_name}"
-            attributes:
-              number: "35"
-
-  collection_season_36:
-    download:
       - url: "{collection_season_36_url}"
         variables:
           collection_season_number: "36"
@@ -633,16 +280,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_36_name}"
-            attributes:
-              number: "36"
-
-  collection_season_37:
-    download:
       - url: "{collection_season_37_url}"
         variables:
           collection_season_number: "37"
@@ -650,16 +287,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_37_name}"
-            attributes:
-              number: "37"
-
-  collection_season_38:
-    download:
       - url: "{collection_season_38_url}"
         variables:
           collection_season_number: "38"
@@ -667,16 +294,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_38_name}"
-            attributes:
-              number: "38"
-
-  collection_season_39:
-    download:
       - url: "{collection_season_39_url}"
         variables:
           collection_season_number: "39"
@@ -684,16 +301,6 @@ presets:
         playlist_thumbnails:
           - name: "{season_poster_file_name}"
             uid: "latest_entry"
-
-    output_directory_nfo_tags:
-      tags:
-        namedseason:
-          - tag: "{collection_season_39_name}"
-            attributes:
-              number: "39"
-
-  collection_season_40:
-    download:
       - url: "{collection_season_40_url}"
         variables:
           collection_season_number: "40"
@@ -705,10 +312,257 @@ presets:
     output_directory_nfo_tags:
       tags:
         namedseason:
+          - tag: "{collection_season_1_name}"
+            attributes:
+              number: "1"
+          - tag: "{collection_season_2_name}"
+            attributes:
+              number: "2"
+          - tag: "{collection_season_3_name}"
+            attributes:
+              number: "3"
+          - tag: "{collection_season_4_name}"
+            attributes:
+              number: "4"
+          - tag: "{collection_season_5_name}"
+            attributes:
+              number: "5"
+          - tag: "{collection_season_6_name}"
+            attributes:
+              number: "6"
+          - tag: "{collection_season_7_name}"
+            attributes:
+              number: "7"
+          - tag: "{collection_season_8_name}"
+            attributes:
+              number: "8"
+          - tag: "{collection_season_9_name}"
+            attributes:
+              number: "9"
+          - tag: "{collection_season_10_name}"
+            attributes:
+              number: "10"
+          - tag: "{collection_season_11_name}"
+            attributes:
+              number: "11"
+          - tag: "{collection_season_12_name}"
+            attributes:
+              number: "12"
+          - tag: "{collection_season_13_name}"
+            attributes:
+              number: "13"
+          - tag: "{collection_season_14_name}"
+            attributes:
+              number: "14"
+          - tag: "{collection_season_15_name}"
+            attributes:
+              number: "15"
+          - tag: "{collection_season_16_name}"
+            attributes:
+              number: "16"
+          - tag: "{collection_season_17_name}"
+            attributes:
+              number: "17"
+          - tag: "{collection_season_18_name}"
+            attributes:
+              number: "18"
+          - tag: "{collection_season_19_name}"
+            attributes:
+              number: "19"
+          - tag: "{collection_season_20_name}"
+            attributes:
+              number: "20"
+          - tag: "{collection_season_21_name}"
+            attributes:
+              number: "21"
+          - tag: "{collection_season_22_name}"
+            attributes:
+              number: "22"
+          - tag: "{collection_season_23_name}"
+            attributes:
+              number: "23"
+          - tag: "{collection_season_24_name}"
+            attributes:
+              number: "24"
+          - tag: "{collection_season_25_name}"
+            attributes:
+              number: "25"
+          - tag: "{collection_season_26_name}"
+            attributes:
+              number: "26"
+          - tag: "{collection_season_27_name}"
+            attributes:
+              number: "27"
+          - tag: "{collection_season_28_name}"
+            attributes:
+              number: "28"
+          - tag: "{collection_season_29_name}"
+            attributes:
+              number: "29"
+          - tag: "{collection_season_30_name}"
+            attributes:
+              number: "30"
+          - tag: "{collection_season_31_name}"
+            attributes:
+              number: "31"
+          - tag: "{collection_season_32_name}"
+            attributes:
+              number: "32"
+          - tag: "{collection_season_33_name}"
+            attributes:
+              number: "33"
+          - tag: "{collection_season_34_name}"
+            attributes:
+              number: "34"
+          - tag: "{collection_season_35_name}"
+            attributes:
+              number: "35"
+          - tag: "{collection_season_36_name}"
+            attributes:
+              number: "36"
+          - tag: "{collection_season_37_name}"
+            attributes:
+              number: "37"
+          - tag: "{collection_season_38_name}"
+            attributes:
+              number: "38"
+          - tag: "{collection_season_39_name}"
+            attributes:
+              number: "39"
           - tag: "{collection_season_40_name}"
             attributes:
               number: "40"
 
+    overrides:
+      collection_season_number_padded: "{ %pad_zero(%int(collection_season_number), 2) }"
+      season_number: "{collection_season_number}"
+      season_number_padded: "{collection_season_number_padded}"
+
+      collection_season_1_url: ""
+      collection_season_1_name: ""
+      collection_season_2_url: ""
+      collection_season_2_name: ""
+      collection_season_3_url: ""
+      collection_season_3_name: ""
+      collection_season_4_url: ""
+      collection_season_4_name: ""
+      collection_season_5_url: ""
+      collection_season_5_name: ""
+      collection_season_6_url: ""
+      collection_season_6_name: ""
+      collection_season_7_url: ""
+      collection_season_7_name: ""
+      collection_season_8_url: ""
+      collection_season_8_name: ""
+      collection_season_9_url: ""
+      collection_season_9_name: ""
+      collection_season_10_url: ""
+      collection_season_10_name: ""
+      collection_season_11_url: ""
+      collection_season_11_name: ""
+      collection_season_12_url: ""
+      collection_season_12_name: ""
+      collection_season_13_url: ""
+      collection_season_13_name: ""
+      collection_season_14_url: ""
+      collection_season_14_name: ""
+      collection_season_15_url: ""
+      collection_season_15_name: ""
+      collection_season_16_url: ""
+      collection_season_16_name: ""
+      collection_season_17_url: ""
+      collection_season_17_name: ""
+      collection_season_18_url: ""
+      collection_season_18_name: ""
+      collection_season_19_url: ""
+      collection_season_19_name: ""
+      collection_season_20_url: ""
+      collection_season_20_name: ""
+      collection_season_21_url: ""
+      collection_season_21_name: ""
+      collection_season_22_url: ""
+      collection_season_22_name: ""
+      collection_season_23_url: ""
+      collection_season_23_name: ""
+      collection_season_24_url: ""
+      collection_season_24_name: ""
+      collection_season_25_url: ""
+      collection_season_25_name: ""
+      collection_season_26_url: ""
+      collection_season_26_name: ""
+      collection_season_27_url: ""
+      collection_season_27_name: ""
+      collection_season_28_url: ""
+      collection_season_28_name: ""
+      collection_season_29_url: ""
+      collection_season_29_name: ""
+      collection_season_30_url: ""
+      collection_season_30_name: ""
+      collection_season_31_url: ""
+      collection_season_31_name: ""
+      collection_season_32_url: ""
+      collection_season_32_name: ""
+      collection_season_33_url: ""
+      collection_season_33_name: ""
+      collection_season_34_url: ""
+      collection_season_34_name: ""
+      collection_season_35_url: ""
+      collection_season_35_name: ""
+      collection_season_36_url: ""
+      collection_season_36_name: ""
+      collection_season_37_url: ""
+      collection_season_37_name: ""
+      collection_season_38_url: ""
+      collection_season_38_name: ""
+      collection_season_39_url: ""
+      collection_season_39_name: ""
+      collection_season_40_url: ""
+      collection_season_40_name: ""
+
+
+####################################################################################################
+# DEPRECATED SEASON PRESETS
+
+  collection_season_1: {}
+  collection_season_2: {}
+  collection_season_3: {}
+  collection_season_4: {}
+  collection_season_5: {}
+  collection_season_6: {}
+  collection_season_7: {}
+  collection_season_8: {}
+  collection_season_9: {}
+  collection_season_10: {}
+  collection_season_11: {}
+  collection_season_12: {}
+  collection_season_13: {}
+  collection_season_14: {}
+  collection_season_15: {}
+  collection_season_16: {}
+  collection_season_17: {}
+  collection_season_18: {}
+  collection_season_19: {}
+  collection_season_20: {}
+  collection_season_21: {}
+  collection_season_22: {}
+  collection_season_23: {}
+  collection_season_24: {}
+  collection_season_25: {}
+  collection_season_26: {}
+  collection_season_27: {}
+  collection_season_28: {}
+  collection_season_29: {}
+  collection_season_30: {}
+  collection_season_31: {}
+  collection_season_32: {}
+  collection_season_33: {}
+  collection_season_34: {}
+  collection_season_35: {}
+  collection_season_36: {}
+  collection_season_37: {}
+  collection_season_38: {}
+  collection_season_39: {}
+  collection_season_40: {}
 
   ###############
 

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
@@ -1,5 +1,25 @@
 presets:
 
+  ###############################
+  # All-in-one presets that require no config
+
+  "Kodi TV Show Collection":
+    preset:
+      - "kodi_tv_show_collection"
+      - "season_by_collection__episode_by_year_month_day"
+
+  "Jellyfin TV Show Collection":
+    preset:
+      - "jellyfin_tv_show_collection"
+      - "season_by_collection__episode_by_year_month_day"
+
+  "Plex TV Show Collection":
+    preset:
+      - "plex_tv_show_collection"
+      - "season_by_collection__episode_by_year_month_day"
+
+  ##################
+
   kodi_tv_show_collection:
     preset:
       - "_kodi_tv_show"
@@ -14,6 +34,30 @@ presets:
     preset:
       - "_plex_tv_show"
       - "_tv_show_collection"
+
+  ###############################
+
+  season_by_collection__episode_by_year_month_day:
+    overrides:
+      episode_number: "{upload_year_truncated}{upload_month_padded}{upload_day_padded}{upload_date_index_padded}"
+      episode_number_padded: "{episode_number}"
+
+  season_by_collection__episode_by_year_month_day_reversed:
+    overrides:
+      episode_number: "{upload_year_truncated_reversed}{upload_month_reversed_padded}{upload_day_reversed_padded}{upload_date_index_reversed_padded}"
+      episode_number_padded: "{episode_number}"
+
+  season_by_collection__episode_by_playlist_index:
+    overrides:
+      episode_number: "{playlist_index}"
+      episode_number_padded: "{playlist_index_padded6}"
+
+  season_by_collection__episode_by_playlist_index_reversed:
+    overrides:
+      episode_number: "{playlist_index_reversed}"
+      episode_number_padded: "{playlist_index_reversed_padded6}"
+
+  ##############
 
   _tv_show_collection:
     download:
@@ -438,87 +482,171 @@ presets:
       season_number: "{collection_season_number}"
       season_number_padded: "{collection_season_number_padded}"
 
-      collection_season_1_url: ""
-      collection_season_1_name: ""
-      collection_season_2_url: ""
-      collection_season_2_name: ""
-      collection_season_3_url: ""
-      collection_season_3_name: ""
-      collection_season_4_url: ""
-      collection_season_4_name: ""
-      collection_season_5_url: ""
-      collection_season_5_name: ""
-      collection_season_6_url: ""
-      collection_season_6_name: ""
-      collection_season_7_url: ""
-      collection_season_7_name: ""
-      collection_season_8_url: ""
-      collection_season_8_name: ""
-      collection_season_9_url: ""
-      collection_season_9_name: ""
-      collection_season_10_url: ""
-      collection_season_10_name: ""
-      collection_season_11_url: ""
-      collection_season_11_name: ""
-      collection_season_12_url: ""
-      collection_season_12_name: ""
-      collection_season_13_url: ""
-      collection_season_13_name: ""
-      collection_season_14_url: ""
-      collection_season_14_name: ""
-      collection_season_15_url: ""
-      collection_season_15_name: ""
-      collection_season_16_url: ""
-      collection_season_16_name: ""
-      collection_season_17_url: ""
-      collection_season_17_name: ""
-      collection_season_18_url: ""
-      collection_season_18_name: ""
-      collection_season_19_url: ""
-      collection_season_19_name: ""
-      collection_season_20_url: ""
-      collection_season_20_name: ""
-      collection_season_21_url: ""
-      collection_season_21_name: ""
-      collection_season_22_url: ""
-      collection_season_22_name: ""
-      collection_season_23_url: ""
-      collection_season_23_name: ""
-      collection_season_24_url: ""
-      collection_season_24_name: ""
-      collection_season_25_url: ""
-      collection_season_25_name: ""
-      collection_season_26_url: ""
-      collection_season_26_name: ""
-      collection_season_27_url: ""
-      collection_season_27_name: ""
-      collection_season_28_url: ""
-      collection_season_28_name: ""
-      collection_season_29_url: ""
-      collection_season_29_name: ""
-      collection_season_30_url: ""
-      collection_season_30_name: ""
-      collection_season_31_url: ""
-      collection_season_31_name: ""
-      collection_season_32_url: ""
-      collection_season_32_name: ""
-      collection_season_33_url: ""
-      collection_season_33_name: ""
-      collection_season_34_url: ""
-      collection_season_34_name: ""
-      collection_season_35_url: ""
-      collection_season_35_name: ""
-      collection_season_36_url: ""
-      collection_season_36_name: ""
-      collection_season_37_url: ""
-      collection_season_37_name: ""
-      collection_season_38_url: ""
-      collection_season_38_name: ""
-      collection_season_39_url: ""
-      collection_season_39_name: ""
-      collection_season_40_url: ""
-      collection_season_40_name: ""
+      # Legacy name variable
+      collection_season_1_name: "{s01_name}"
+      collection_season_2_name: "{s02_name}"
+      collection_season_3_name: "{s03_name}"
+      collection_season_4_name: "{s04_name}"
+      collection_season_5_name: "{s05_name}"
+      collection_season_6_name: "{s06_name}"
+      collection_season_7_name: "{s07_name}"
+      collection_season_8_name: "{s08_name}"
+      collection_season_9_name: "{s09_name}"
+      collection_season_10_name: "{s10_name}"
+      collection_season_11_name: "{s11_name}"
+      collection_season_12_name: "{s12_name}"
+      collection_season_13_name: "{s13_name}"
+      collection_season_14_name: "{s14_name}"
+      collection_season_15_name: "{s15_name}"
+      collection_season_16_name: "{s16_name}"
+      collection_season_17_name: "{s17_name}"
+      collection_season_18_name: "{s18_name}"
+      collection_season_19_name: "{s19_name}"
+      collection_season_20_name: "{s20_name}"
+      collection_season_21_name: "{s21_name}"
+      collection_season_22_name: "{s22_name}"
+      collection_season_23_name: "{s23_name}"
+      collection_season_24_name: "{s24_name}"
+      collection_season_25_name: "{s25_name}"
+      collection_season_26_name: "{s26_name}"
+      collection_season_27_name: "{s27_name}"
+      collection_season_28_name: "{s28_name}"
+      collection_season_29_name: "{s29_name}"
+      collection_season_30_name: "{s30_name}"
+      collection_season_31_name: "{s31_name}"
+      collection_season_32_name: "{s32_name}"
+      collection_season_33_name: "{s33_name}"
+      collection_season_34_name: "{s34_name}"
+      collection_season_35_name: "{s35_name}"
+      collection_season_36_name: "{s36_name}"
+      collection_season_37_name: "{s37_name}"
+      collection_season_38_name: "{s38_name}"
+      collection_season_39_name: "{s39_name}"
+      collection_season_40_name: "{s40_name}"
 
+      # Legacy url variable
+      collection_season_1_url: "{s01_url}"
+      collection_season_2_url: "{s02_url}"
+      collection_season_3_url: "{s03_url}"
+      collection_season_4_url: "{s04_url}"
+      collection_season_5_url: "{s05_url}"
+      collection_season_6_url: "{s06_url}"
+      collection_season_7_url: "{s07_url}"
+      collection_season_8_url: "{s08_url}"
+      collection_season_9_url: "{s09_url}"
+      collection_season_10_url: "{s10_url}"
+      collection_season_11_url: "{s11_url}"
+      collection_season_12_url: "{s12_url}"
+      collection_season_13_url: "{s13_url}"
+      collection_season_14_url: "{s14_url}"
+      collection_season_15_url: "{s15_url}"
+      collection_season_16_url: "{s16_url}"
+      collection_season_17_url: "{s17_url}"
+      collection_season_18_url: "{s18_url}"
+      collection_season_19_url: "{s19_url}"
+      collection_season_20_url: "{s20_url}"
+      collection_season_21_url: "{s21_url}"
+      collection_season_22_url: "{s22_url}"
+      collection_season_23_url: "{s23_url}"
+      collection_season_24_url: "{s24_url}"
+      collection_season_25_url: "{s25_url}"
+      collection_season_26_url: "{s26_url}"
+      collection_season_27_url: "{s27_url}"
+      collection_season_28_url: "{s28_url}"
+      collection_season_29_url: "{s29_url}"
+      collection_season_30_url: "{s30_url}"
+      collection_season_31_url: "{s31_url}"
+      collection_season_32_url: "{s32_url}"
+      collection_season_33_url: "{s33_url}"
+      collection_season_34_url: "{s34_url}"
+      collection_season_35_url: "{s35_url}"
+      collection_season_36_url: "{s36_url}"
+      collection_season_37_url: "{s37_url}"
+      collection_season_38_url: "{s38_url}"
+      collection_season_39_url: "{s39_url}"
+      collection_season_40_url: "{s40_url}"
+
+      s01_name: ""
+      s02_name: ""
+      s03_name: ""
+      s04_name: ""
+      s05_name: ""
+      s06_name: ""
+      s07_name: ""
+      s08_name: ""
+      s09_name: ""
+      s10_name: ""
+      s11_name: ""
+      s12_name: ""
+      s13_name: ""
+      s14_name: ""
+      s15_name: ""
+      s16_name: ""
+      s17_name: ""
+      s18_name: ""
+      s19_name: ""
+      s20_name: ""
+      s21_name: ""
+      s22_name: ""
+      s23_name: ""
+      s24_name: ""
+      s25_name: ""
+      s26_name: ""
+      s27_name: ""
+      s28_name: ""
+      s29_name: ""
+      s30_name: ""
+      s31_name: ""
+      s32_name: ""
+      s33_name: ""
+      s34_name: ""
+      s35_name: ""
+      s36_name: ""
+      s37_name: ""
+      s38_name: ""
+      s39_name: ""
+      s40_name: ""
+
+      s01_url: ""
+      s02_url: ""
+      s03_url: ""
+      s04_url: ""
+      s05_url: ""
+      s06_url: ""
+      s07_url: ""
+      s08_url: ""
+      s09_url: ""
+      s10_url: ""
+      s11_url: ""
+      s12_url: ""
+      s13_url: ""
+      s14_url: ""
+      s15_url: ""
+      s16_url: ""
+      s17_url: ""
+      s18_url: ""
+      s19_url: ""
+      s20_url: ""
+      s21_url: ""
+      s22_url: ""
+      s23_url: ""
+      s24_url: ""
+      s25_url: ""
+      s26_url: ""
+      s27_url: ""
+      s28_url: ""
+      s29_url: ""
+      s30_url: ""
+      s31_url: ""
+      s32_url: ""
+      s33_url: ""
+      s34_url: ""
+      s35_url: ""
+      s36_url: ""
+      s37_url: ""
+      s38_url: ""
+      s39_url: ""
+      s40_url: ""
 
 ####################################################################################################
 # DEPRECATED SEASON PRESETS
@@ -563,25 +691,3 @@ presets:
   collection_season_38: {}
   collection_season_39: {}
   collection_season_40: {}
-
-  ###############
-
-  season_by_collection__episode_by_year_month_day:
-    overrides:
-      episode_number: "{upload_year_truncated}{upload_month_padded}{upload_day_padded}{upload_date_index_padded}"
-      episode_number_padded: "{episode_number}"
-
-  season_by_collection__episode_by_year_month_day_reversed:
-    overrides:
-      episode_number: "{upload_year_truncated_reversed}{upload_month_reversed_padded}{upload_day_reversed_padded}{upload_date_index_reversed_padded}"
-      episode_number_padded: "{episode_number}"
-
-  season_by_collection__episode_by_playlist_index:
-    overrides:
-      episode_number: "{playlist_index}"
-      episode_number_padded: "{playlist_index_padded6}"
-
-  season_by_collection__episode_by_playlist_index_reversed:
-    overrides:
-      episode_number: "{playlist_index_reversed}"
-      episode_number_padded: "{playlist_index_reversed_padded6}"

--- a/tests/resources/expected_downloads_summaries/youtube/test_channel_full.json
+++ b/tests/resources/expected_downloads_summaries/youtube/test_channel_full.json
@@ -26,7 +26,7 @@
   "Project ⧸ Zombie/Season 2011/s2011.e052901 - Project Zombie ｜Official Trailer｜ (IP： mc.projectzombie.beastnode.net).nfo": "cb0184784a8eda842cfaf851f6e6af7d",
   "Project ⧸ Zombie/Season 2011/s2011.e063001 - Project Zombie ｜Fin｜-thumb.jpg": "00ed383591779ffe98291de60f198fe9",
   "Project ⧸ Zombie/Season 2011/s2011.e063001 - Project Zombie ｜Fin｜.info.json": "INFO_JSON",
-  "Project ⧸ Zombie/Season 2011/s2011.e063001 - Project Zombie ｜Fin｜.mp4": "5f9f8841aed3f5d95efbd1839045741e",
+  "Project ⧸ Zombie/Season 2011/s2011.e063001 - Project Zombie ｜Fin｜.mp4": "b20822d0f7217c9f0a0ccf83e33f8187",
   "Project ⧸ Zombie/Season 2011/s2011.e063001 - Project Zombie ｜Fin｜.nfo": "54ea4a48116aa98480a79495036c25e9",
   "Project ⧸ Zombie/Season 2011/s2011.e112101 - Skyrim 'Ultra HD w⧸Mods' [PC]-thumb.jpg": "1718599d5189c65f7d8cf6acfa5ea851",
   "Project ⧸ Zombie/Season 2011/s2011.e112101 - Skyrim 'Ultra HD w⧸Mods' [PC].info.json": "INFO_JSON",

--- a/tests/unit/config/test_subscription.py
+++ b/tests/unit/config/test_subscription.py
@@ -416,7 +416,7 @@ def test_tv_show_subscriptions(config_file: ConfigFile, tv_show_subscriptions_pa
         config=config_file, subscription_path=tv_show_subscriptions_path
     )
 
-    assert len(subs) == 7
+    assert len(subs) == 8
     assert subs[3].name == "Jake Trains"
     jake_train_overrides = subs[3].overrides.script
 


### PR DESCRIPTION
Simplifies TV Show Collection presets, drastically. Old version:
```
  rick_a_tv_show_collection:
    preset:
      - "jellyfin_tv_show_collection"
      - "season_by_collection__episode_by_year_month_day_reversed"
      - "collection_season_1"
      - "collection_season_2"
    overrides:
      tv_show_name: "Rick A"
      collection_season_1_url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
      collection_season_1_name: "All Videos"
      collection_season_2_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"
      collection_season_2_name: "Official Music Videos"
```

New version:
```
  Jellyfin TV Show Collection:
    "~Rick A":
      s01_name: "All Videos"
      s01_url: "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
      s02_name: "Official Music Videos"
      s02_url: "https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc"
```