### PR TITLE
[BUGFIX] Do not run all branches of `if` functions in scripts

### DIFF
--- a/src/ytdl_sub/script/functions/conditional_functions.py
+++ b/src/ytdl_sub/script/functions/conditional_functions.py
@@ -18,8 +18,8 @@ class ConditionalFunctions:
           depending on the ``condition`` value.
         """
         if condition.value:
-            return true
-        return false
+            return true.value()
+        return false.value()
 
     @staticmethod
     def elif_(*if_elif_else: AnyArgument) -> AnyArgument:
@@ -50,9 +50,9 @@ class ConditionalFunctions:
 
         for idx in range(0, len(arguments) - 1, 2):
             if bool(arguments[idx].value):
-                return arguments[idx + 1]
+                return arguments[idx + 1].value()
 
-        return arguments[-1]
+        return arguments[-1].value()
 
     @staticmethod
     def if_passthrough(
@@ -63,6 +63,7 @@ class ConditionalFunctions:
           Conditional ``if`` statement that returns the ``maybe_true_arg`` if it evaluates to True,
           otherwise returns ``else_arg``.
         """
-        if bool(maybe_true_arg.value):
-            return maybe_true_arg
-        return else_arg
+        maybe_true_value = maybe_true_arg.value()
+        if bool(maybe_true_value.value):
+            return maybe_true_value
+        return else_arg.value()

--- a/src/ytdl_sub/script/script.py
+++ b/src/ytdl_sub/script/script.py
@@ -7,6 +7,7 @@ from typing import Set
 from ytdl_sub.script.functions import Functions
 from ytdl_sub.script.parser import parse
 from ytdl_sub.script.script_output import ScriptOutput
+from ytdl_sub.script.types.resolvable import BuiltInFunctionType
 from ytdl_sub.script.types.resolvable import Lambda
 from ytdl_sub.script.types.resolvable import Resolvable
 from ytdl_sub.script.types.syntax_tree import SyntaxTree
@@ -146,18 +147,38 @@ class Script:
         self, prefix: str, name: str, definition: SyntaxTree
     ):
         for function in definition.built_in_functions:
-            spec = FunctionSpec.from_callable(Functions.get(function.name))
+            for arg in function.args:
+                self._ensure_lambda_usage_num_input_arguments_valid(
+                    prefix=prefix, name=name, definition=SyntaxTree([arg])
+                )
+
+            spec = FunctionSpec.from_callable(
+                name=function.name, callable_ref=Functions.get(function.name)
+            )
             if not (lambda_type := spec.is_lambda_like):
                 return
 
-            lambda_function_names = set(
-                lamb.value for lamb in SyntaxTree(function.args).lambdas if isinstance(lamb, Lambda)
-            )
+            lambda_function_names: Set[str] = set()
+            for lamb in SyntaxTree(function.args).lambdas:
+                if lamb in function.args:
+                    lambda_function_names.add(lamb.value)
+
+                # See if the arg outputs a lambda (from an if).
+                # If so, add the possible lambda to be checked
+                for arg in function.args:
+                    if (
+                        isinstance(arg, BuiltInFunctionType)
+                        and arg.output_type() == Lambda
+                        and lamb in arg.args
+                    ):
+                        lambda_function_names.add(lamb.value)
 
             # Only case len(lambda_function_names) > 1 is when used in if-statements
             for lambda_function_name in lambda_function_names:
                 if Functions.is_built_in(lambda_function_name):
-                    lambda_spec = FunctionSpec.from_callable(Functions.get(lambda_function_name))
+                    lambda_spec = FunctionSpec.from_callable(
+                        name=lambda_function_name, callable_ref=Functions.get(lambda_function_name)
+                    )
                     if not lambda_spec.is_num_args_compatible(lambda_type.num_input_args()):
                         expected_args_str = str(lambda_spec.num_required_args)
                         if lambda_spec.num_required_args != len(lambda_spec.args):
@@ -366,13 +387,15 @@ class Script:
 
                 # If the variable's variable dependencies contain an unresolvable variable,
                 # declare it as unresolvable and continue
-                elif definition.contains(unresolvable):
+                elif definition.contains(unresolvable, custom_function_definitions=self._functions):
                     unresolvable.add(variable)
                     del unresolved[variable]
 
                 # Otherwise, if it has dependencies that are all resolved, then
                 # resolve the definition
-                elif not definition.is_subset_of(variables=resolved.keys()):
+                elif not definition.is_subset_of(
+                    variables=resolved.keys(), custom_function_definitions=self._functions
+                ):
                     resolved[variable] = unresolved[variable].resolve(
                         resolved_variables=resolved,
                         custom_functions=self._functions,

--- a/src/ytdl_sub/script/types/variable_dependency.py
+++ b/src/ytdl_sub/script/types/variable_dependency.py
@@ -43,7 +43,7 @@ class VariableDependency(ABC):
                 output.append(arg)
             elif instance and isinstance(arg, ttype):
                 output.append(arg)
-            elif type(arg) == ttype:
+            elif type(arg) == ttype:  # pylint: disable=unidiomatic-typecheck
                 output.append(arg)
 
             if isinstance(arg, VariableDependency):

--- a/src/ytdl_sub/utils/script.py
+++ b/src/ytdl_sub/utils/script.py
@@ -13,6 +13,7 @@ from ytdl_sub.script.types.resolvable import Argument
 from ytdl_sub.script.types.resolvable import Boolean
 from ytdl_sub.script.types.resolvable import Float
 from ytdl_sub.script.types.resolvable import Integer
+from ytdl_sub.script.types.resolvable import Lambda
 from ytdl_sub.script.types.resolvable import String
 from ytdl_sub.script.types.variable import Variable
 from ytdl_sub.script.utils.exceptions import UNREACHABLE
@@ -115,6 +116,8 @@ class ScriptUtils:
             out = arg.name
         elif isinstance(arg, Function):
             out = f"%{arg.name}( {', '.join(cls._to_script_code(val) for val in arg.args)} )"
+        elif isinstance(arg, Lambda):
+            out = f"%{arg.value}"
         else:
             raise UNREACHABLE
         return f"{{ {out} }}" if top_level else out

--- a/tests/unit/script/functions/test_conditional_functions.py
+++ b/tests/unit/script/functions/test_conditional_functions.py
@@ -101,3 +101,37 @@ class TestConditionalFunction:
                 )
             }"""
             )
+
+    @pytest.mark.parametrize(
+        "function_str, expected_output",
+        [
+            ("{%if(True, True, %assert(False, 'should not reach'))}", True),
+            ("{%if(False, %assert(False, 'should not reach'), False)}", False),
+        ],
+    )
+    def test_if_function_only_evaluates_branch(self, function_str: str, expected_output: bool):
+        output = single_variable_output(function_str)
+        assert output == expected_output
+
+    @pytest.mark.parametrize(
+        "function_str, expected_output",
+        [
+            ("{%elif(True, True, %assert(False, 'should not reach'))}", True),
+            ("{%elif(False, %assert(False, 'should not reach'), False)}", False),
+        ],
+    )
+    def test_elif_function_only_evaluates_branch(self, function_str: str, expected_output: bool):
+        output = single_variable_output(function_str)
+        assert output == expected_output
+
+    @pytest.mark.parametrize(
+        "function_str, expected_output",
+        [
+            ("{%if_passthrough(True, %assert(False, 'should not reach'))}", True),
+        ],
+    )
+    def test_if_passthrough_function_only_evaluates_branch(
+        self, function_str: str, expected_output: bool
+    ):
+        output = single_variable_output(function_str)
+        assert output == expected_output

--- a/tests/unit/script/types/test_lambda_function.py
+++ b/tests/unit/script/types/test_lambda_function.py
@@ -15,6 +15,11 @@ class TestLambdaFunction:
             {"%times_two": "{%mul($0, 2)}", "wip": "{%array_apply([1, 2, 3], %times_two)}"}
         ).resolve() == ScriptOutput({"wip": Array([Integer(2), Integer(4), Integer(6)])})
 
+    def test_lambda_with_custom_function_empty_input(self):
+        assert Script(
+            {"%times_two": "{%mul($0, 2)}", "wip": "{%array_apply([], %times_two)}"}
+        ).resolve() == ScriptOutput({"wip": Array([])})
+
     def test_conditional_lambda_with_custom_functions(self):
         assert Script(
             {
@@ -53,6 +58,23 @@ class TestLambdaFunction:
                 "output": "{%array_at(%array_apply([2], %nest1), 0)}",
             }
         ).resolve() == ScriptOutput({"output": Integer(4)})
+
+    def test_multiple_lambdas_single_definition(self):
+        url_map_def = """{
+                %array_reduce(
+                    %array_apply( array_def, %array_map_format),
+                    %map_extend
+                )
+            }"""
+        script = Script(
+            {
+                "%array_map_format": "{ {$0: $0 } }",
+                "array_def": "{ [1, 2, 3] }",
+                "category_url_map": url_map_def,
+            }
+        )
+
+        assert script.resolve().get("category_url_map").native == {1: 1, 2: 2, 3: 3}
 
 
 class TestLambdaFunctionIncompatibleNumArguments:

--- a/tools/docgen/scripting_functions.py
+++ b/tools/docgen/scripting_functions.py
@@ -30,7 +30,7 @@ def function_class_to_name(obj: Type[Any]) -> str:
 
 
 def function_type_hinting(display_function_name: str, function: Any) -> str:
-    spec = FunctionSpec.from_callable(function)
+    spec = FunctionSpec.from_callable(name=display_function_name, callable_ref=function)
     out = ":spec: ``"
     out += display_function_name
     out += spec.human_readable_input_args()


### PR DESCRIPTION
Will only run branches of `if` statements if the condition evaluates to that branch