### PR TITLE
Fixing 404 link to presets

### DIFF
--- a/docker/root/defaults/config.yaml
+++ b/docker/root/defaults/config.yaml
@@ -1,7 +1,7 @@
 # Bare-bones config. Here are some useful links to get started:
 #   Walk-through Guide:  https://ytdl-sub.readthedocs.io/en/latest/guides/index.html
 #   Config Examples:     https://github.com/jmbannon/ytdl-sub/tree/master/examples
-#   Prebuilt Presets:    https://ytdl-sub.readthedocs.io/en/latest/presets.html
+#   Prebuilt Presets:    https://ytdl-sub.readthedocs.io/en/latest/prebuilt_presets/index.html
 #   Config Reference:    https://ytdl-sub.readthedocs.io/en/latest/config_reference/index.html
 #
 # The subscriptions in `subscriptions.yaml` uses prebuilt presets which do not require


### PR DESCRIPTION
Still learning how to use this project but I noticed the link in the default config seems to be a 404, I added what I believe to be the correct one in its place