### PR TITLE
update paths in documentation for automatic downlaods

### DIFF
--- a/docker/root/custom-cont-init.d/defaults-gui
+++ b/docker/root/custom-cont-init.d/defaults-gui
@@ -8,15 +8,15 @@ fi
 echo "Checking ytdl-sub-gui defaults..."
 
 # copy config
-[[ ! -e /config/ytdl-sub-configs/config.yaml ]] && \
+[[ ! -e /config/config.yaml ]] && \
     mkdir -p /config/ytdl-sub-configs && \
-    cp /defaults/config.yaml /config/ytdl-sub-configs/config.yaml
-[[ ! -e /config/ytdl-sub-configs/subscriptions.yaml ]] && \
+    cp /defaults/config.yaml /config/config.yaml
+[[ ! -e /config/subscriptions.yaml ]] && \
     mkdir -p /config/ytdl-sub-configs && \
-    cp /defaults/subscriptions.yaml /config/ytdl-sub-configs/subscriptions.yaml
-[[ ! -d /config/ytdl-sub-configs/examples ]] && \
-    mkdir -p /config/ytdl-sub-configs/examples && \
-    cp /defaults/examples/* /config/ytdl-sub-configs/examples
+    cp /defaults/subscriptions.yaml /config/subscriptions.yaml
+[[ ! -d /config/examples ]] && \
+    mkdir -p /config/examples && \
+    cp /defaults/examples/* /config/examples
 
 # permissions
 chown -R ${PUID:-abc}:${PGID:-abc} \

--- a/docs/source/guides/getting_started/automating_downloads.rst
+++ b/docs/source/guides/getting_started/automating_downloads.rst
@@ -21,32 +21,32 @@ Docker and Unraid
   
   .. tab-item:: GUI Image
     
-    The script that will execute automatically is located at ``/config/ytdl-sub-configs/run-cron``. 
+    The script that will execute automatically is located at ``/config/run_cron``. 
 
     Access your container at http://localhost:8443/, then in the GUI terminal run these commands:
 
     .. code-block:: shell
 
-      echo '#!/bin/bash' > /config/ytdl-sub-configs/run_cron
-      echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> /config/ytdl-sub-configs/run_cron
-      echo "echo 'Cron started, running ytdl-sub...'" >> /config/ytdl-sub-configs/run_cron
-      echo "cd /config/ytdl-sub-configs" >> /config/ytdl-sub-configs/run_cron
-      echo "ytdl-sub --config=config.yaml sub subscriptions.yaml" >> /config/ytdl-sub-configs/run_cron
-      chmod +x /config/ytdl-sub-configs/run_cron
-      chown abc:abc /config/ytdl-sub-configs/run_cron
+      echo '#!/bin/bash' > /config/run_cron
+      echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> /config/run_cron
+      echo "echo 'Cron started, running ytdl-sub...'" >> /config/run_cron
+      echo "cd /config/ytdl-sub-configs" >> /config/run_cron
+      echo "ytdl-sub --config=config.yaml sub subscriptions.yaml" >> /config/run_cron
+      chmod +x /config/run_cron
+      chown abc:abc /config/run_cron
 
     You can test the newly created script by running: 
 
     .. code-block:: shell
 
-      /config/ytdl-sub-configs/run_cron
+      /config/run_cron
 
     To create the cron definition, run the following command:
 
     .. code-block:: shell
 
       echo "# min   hour    day     month   weekday command" > /config/crontabs/abc
-      echo "  0     */6     *       *       *       /config/ytdl-sub-configs/run_cron" >> /config/crontabs/abc
+      echo "  0     */6     *       *       *       /config/run_cron" >> /config/crontabs/abc
 
     This will run the script every 6 hours. To run every hour, change ``*/6`` to ``*/1``, or to run once a day, change the same value to the hour (in 24hr format) that you want it to run at. See the `cron tab manpage`_ for more options.
 
@@ -81,7 +81,7 @@ Docker and Unraid
 
       docker compose restart
 
-    The script that will execute automatically is located at ``/config/run-cron``. 
+    The script that will execute automatically is located at ``/config/run_cron``. 
 
     Access your container from the terminal by running:
 
@@ -93,13 +93,13 @@ Docker and Unraid
 
     .. code-block:: shell
 
-      echo '#!/bin/bash' > /config/ytdl-sub-configs/run_cron
-      echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> /config/ytdl-sub-configs/run_cron
-      echo "echo 'Cron started, running ytdl-sub...'" >> /config/ytdl-sub-configs/run_cron
-      echo "cd /config/ytdl-sub-configs" >> /config/ytdl-sub-configs/run_cron
-      echo "ytdl-sub --config=config.yaml sub subscriptions.yaml" >> /config/ytdl-sub-configs/run_cron
-      chmod +x /config/ytdl-sub-configs/run_cron
-      chown abc:abc /config/ytdl-sub-configs/run_cron
+      echo '#!/bin/bash' > /config/run_cron
+      echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> /config/run_cron
+      echo "echo 'Cron started, running ytdl-sub...'" >> /config/run_cron
+      echo "cd /config/ytdl-sub-configs" >> /config/run_cron
+      echo "ytdl-sub --config=config.yaml sub subscriptions.yaml" >> /config/run_cron
+      chmod +x /config/run_cron
+      chown abc:abc /config/run_cron
 
     You can test the newly created script by running: 
 


### PR DESCRIPTION
Trying to follow the documentation for automating downloads, it was confusing because the path for the `run_cron` script was inconsistent.  

Sometimes it was `/config/ytdl-sub-configs/run_cron`, somtimes `config/run-cron`, and sometimes `config/run_cron`.

I updated the documentation and bash scripts to always use `config/run_cron`.