### PR TITLE
[DOCS] Add note to restart Docker container

### DIFF
--- a/docs/source/guides/getting_started/automating_downloads.rst
+++ b/docs/source/guides/getting_started/automating_downloads.rst
@@ -52,6 +52,9 @@ Docker and Unraid
 
     This will run the script every 6 hours. To run every hour, change ``*/6`` to ``*/1``, or to run once a day, change the same value to the hour (in 24hr format) that you want it to run at. See the `cron tab manpage`_ for more options.
 
+    .. attention::
+      The Docker container needs to be restarted for changes to take effect. Run `crontab -e` after to verify settings are correct.
+
   .. tab-item:: Headless Image
 
     .. _LinuxServer's Universal Cron mod: https://github.com/linuxserver/docker-mods/tree/universal-cron
@@ -117,6 +120,9 @@ Docker and Unraid
       echo "  0     */6     *       *       *       /config/run_cron" >> /config/crontabs/abc
     
     This will run the script every 6 hours. To run every hour, change ``*/6`` to ``*/1``, or to run once a day, change the same value to the hour (in 24hr format) that you want it to run at. See the `cron tab manpage`_ for more options.
+    
+    .. attention::
+      The Docker container needs to be restarted for changes to take effect. Run `crontab -e` after to verify settings are correct.
 
 .. _linux-setup:
 


### PR DESCRIPTION
This could be a gap in knowledge on how to run CRON jobs out of a Docker container but it seems like it does come up often. Small change to add a note to tell users to restart their Docker container for changes in the guide to take effect.

![image](https://github.com/user-attachments/assets/b7e7d473-ae58-4b5f-856b-1d2c63ab41f3)


Related:
- #1155 
- https://discord.com/channels/994270357957648404/1238315252525957160/1238315252525957160