### PR TITLE
[BACKEND] Use upload-artifact@v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           mv dist/ytdl-sub /opt/builds/ytdl-sub_${{ matrix.arch }}
 
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ytdl-sub_${{ matrix.arch }}
           path: /opt/builds/ytdl-sub_${{ matrix.arch }}
@@ -124,7 +124,7 @@ jobs:
           .\dist\ytdl-sub.exe -h
 
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ytdl-sub_exe
           path: .\dist\ytdl-sub.exe

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,19 +145,19 @@ jobs:
           echo '${{ needs.version.outputs.init_contents }}' > src/ytdl_sub/__init__.py
 
       - name: Restore exe build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ytdl-sub_exe
           path: /opt/builds
 
       - name: Restore aarch64 build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ytdl-sub_aarch64
           path: /opt/builds
 
       - name: Restore x86_64 build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ytdl-sub_x86_64
           path: /opt/builds


### PR DESCRIPTION
v3 now deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/