### PR TITLE
Make total delete videos in Total stats be negative

### DIFF
--- a/src/ytdl_sub/__init__.py
+++ b/src/ytdl_sub/__init__.py
@@ -1,2 +1,2 @@
 __pypi_version__ = "2023.10.22.post3"
-__local_version__ = "2023.10.22+bfba4f0"
+__local_version__ = "2025.02.12+marvin8"

--- a/src/ytdl_sub/__init__.py
+++ b/src/ytdl_sub/__init__.py
@@ -1,2 +1,2 @@
 __pypi_version__ = "2023.10.22.post3"
-__local_version__ = "2025.02.12+marvin8"
+__local_version__ = "2023.10.22+bfba4f0"

--- a/src/ytdl_sub/cli/output_summary.py
+++ b/src/ytdl_sub/cli/output_summary.py
@@ -99,7 +99,7 @@ def output_summary(subscriptions: List[Subscription]) -> None:
         f"{total_subs_str:<{width_sub_name}} "
         f"{_color_int(total_added):>{width_num_entries_added}} "
         f"{_color_int(total_modified):>{width_num_entries_modified}} "
-        f"{_color_int(total_removed):>{width_num_entries_removed}} "
+        f"{_color_int(total_removed * -1):>{width_num_entries_removed}} "
         f"{total_entries:>{width_num_entries}} "
         f"{total_errors_str}"
     )


### PR DESCRIPTION
Hope this is not too much of a bother. I just had a bit of a hangup seeing the stats at the end of a run of ytdl-sub with how deleted videos where counted.

All I have done is make the total number of deleted videos negative (* -1) as well to be in line with the number of deleted videos for each subscription.

