### PR TITLE
Support duplicate timestamps by merging into single timestamp

### DIFF
--- a/src/ytdl_sub/utils/chapters.py
+++ b/src/ytdl_sub/utils/chapters.py
@@ -220,10 +220,17 @@ class Chapters:
             # Timestamp captured, store it
             if match := Timestamp.TIMESTAMP_REGEX.search(line):
                 timestamp_str = match.group(1)
-                timestamps.append(Timestamp.from_str(timestamp_str))
 
                 # Remove timestamp and surrounding whitespace from it
                 title_str = re.sub(f"\\s*{re.escape(timestamp_str)}\\s*", " ", line).strip()
+
+                timestamp = Timestamp.from_str(timestamp_str)
+                if timestamps and (timestamps[-1].timestamp_sec == timestamp.timestamp_sec):
+                    # duplicate timestamp... combine into one chapter
+                    titles[-1] += " // " + title_str
+                    continue
+                timestamps.append(timestamp)
+
                 titles.append(title_str)
 
         # If more than 3 timestamps were parsed, return it

--- a/tests/unit/utils/test_chapters.py
+++ b/tests/unit/utils/test_chapters.py
@@ -86,6 +86,21 @@ def chapter_description_3() -> str:
 """
 
 
+@pytest.fixture
+def chapter_duplicate_timecodes() -> str:
+    return """01. 00:00 Ocean
+02:41 Dreams
+02:41 Nightmares
+05:16 Future Tales
+08:50 Mind Travelling
+11:05 Love Supreme
+14:17 Reflections
+14:17 Reflections VIP
+16:32 Moonlight Fading
+19:40 Between Two Worlds
+"""
+
+
 class TestChapters:
     def test_chapters_from_str_1(self, chapter_description_1):
         chapters = Chapters.from_string(chapter_description_1)
@@ -104,3 +119,8 @@ class TestChapters:
             chapters.titles[8]
             == "(Nightcore) Electro-Light & Jordan Kelvin James - Wait For You (feat. Anna Yvette)"
         )
+
+    def test_chapters_from_str_with_duplicate_timecodes(self, chapter_duplicate_timecodes):
+        chapters = Chapters.from_string(chapter_duplicate_timecodes)
+        assert len(chapters) == 8
+        assert chapters.titles[5] == "Reflections // Reflections VIP"


### PR DESCRIPTION
Hey there!

I've noticed that ytdl-sub throws an error when duplicate timestamps are found in its check for ascending order. Makes total sense for albums where you only have one track at a time, but I've found user-submitted timestamps for DJ sets sometimes feature these. For example, the top timestamp comment under [this video](https://www.youtube.com/watch?v=AEld3R_MRb4).

This pull request adds support for these duplicate timestamps by combining them into one with a delimiter in the timestamp title to split them up. I can change the delimiter if preferred, but it seemed like a good obvious one.

To find duplicates, I added a comparison to the last added Timestamp. If they match, the last added title is appended with the delimiter and the duplicate timestamp title. The duplicate's Timestamp object is ignored so only a single Chapter is created for that timecode.

Hoping we can get this implemented! Thanks!