### PR TITLE
Add configuration option to suppress colors in output summary

### DIFF
--- a/src/ytdl_sub/cli/entrypoint.py
+++ b/src/ytdl_sub/cli/entrypoint.py
@@ -271,6 +271,6 @@ def main() -> List[Subscription]:
             transaction_log_file_path=args.transaction_log,
         )
 
-    output_summary(subscriptions)
+    output_summary(subscriptions, config=config)
 
     return subscriptions

--- a/src/ytdl_sub/cli/output_summary.py
+++ b/src/ytdl_sub/cli/output_summary.py
@@ -4,20 +4,21 @@ from colorama import Fore
 
 from ytdl_sub.subscriptions.subscription import Subscription
 from ytdl_sub.utils.logger import Logger
+from ytdl_sub.config.config_file import ConfigFile
 
 logger = Logger.get()
 
 
-def _green(value: str) -> str:
-    return Fore.GREEN + value + Fore.RESET
+def _green(value: str, suppress_colors: bool = False) -> str:
+    return value if suppress_colors else Fore.GREEN + value + Fore.RESET
 
 
-def _red(value: str) -> str:
-    return Fore.RED + value + Fore.RESET
+def _red(value: str, suppress_colors: bool = False) -> str:
+    return value if suppress_colors else Fore.RED + value + Fore.RESET
 
 
-def _no_color(value: str) -> str:
-    return Fore.RESET + value + Fore.RESET
+def _no_color(value: str, suppress_colors: bool = False) -> str:
+    return value if suppress_colors else Fore.RESET + value + Fore.RESET
 
 
 def _str_int(value: int) -> str:
@@ -26,21 +27,23 @@ def _str_int(value: int) -> str:
     return str(value)
 
 
-def _color_int(value: int) -> str:
+def _color_int(value: int, suppress_colors: bool = False) -> str:
     str_int = _str_int(value)
     if value > 0:
-        return _green(str_int)
+        return _green(str_int, suppress_colors)
     if value < 0:
-        return _red(str_int)
-    return _no_color(str_int)
+        return _red(str_int, suppress_colors)
+    return _no_color(str_int, suppress_colors)
 
 
-def output_summary(subscriptions: List[Subscription]) -> None:
+def output_summary(subscriptions: List[Subscription], config: ConfigFile) -> None:
     """
     Parameters
     ----------
     subscriptions
         Processed subscriptions
+    config
+        ConfigFile instance
 
     Returns
     -------
@@ -54,6 +57,10 @@ def output_summary(subscriptions: List[Subscription]) -> None:
 
     summary: List[str] = []
 
+    suppress_colors = config.config_options.suppress_colors
+
+    logger.info(f"The suppress_colors option is {suppress_colors}")
+
     # Initialize totals to 0
     total_subs: int = len(subscriptions)
     total_subs_str = f"Total: {total_subs}"
@@ -65,21 +72,21 @@ def output_summary(subscriptions: List[Subscription]) -> None:
 
     # Initialize widths to 0
     width_sub_name: int = max(len(sub.name) for sub in subscriptions) + 4  # aesthetics
-    width_num_entries_added: int = len(_color_int(total_added))
-    width_num_entries_modified: int = len(_color_int(total_modified))
-    width_num_entries_removed: int = len(_color_int(total_removed))
+    width_num_entries_added: int = len(_color_int(total_added, suppress_colors))
+    width_num_entries_modified: int = len(_color_int(total_modified, suppress_colors))
+    width_num_entries_removed: int = len(_color_int(total_removed, suppress_colors))
     width_num_entries: int = len(str(total_entries)) + 4  # aesthetics
 
     # Build the summary
     for subscription in subscriptions:
-        num_entries_added = _color_int(subscription.num_entries_added)
-        num_entries_modified = _color_int(subscription.num_entries_modified)
-        num_entries_removed = _color_int(subscription.num_entries_removed * -1)
+        num_entries_added = _color_int(subscription.num_entries_added, suppress_colors)
+        num_entries_modified = _color_int(subscription.num_entries_modified, suppress_colors)
+        num_entries_removed = _color_int(subscription.num_entries_removed * -1, suppress_colors)
         num_entries = str(subscription.num_entries)
         status = (
-            _red(subscription.exception.__class__.__name__)
+            _red(subscription.exception.__class__.__name__, suppress_colors)
             if subscription.exception
-            else _green("✔")
+            else _green("✔", suppress_colors)
         )
 
         summary.append(
@@ -92,14 +99,14 @@ def output_summary(subscriptions: List[Subscription]) -> None:
         )
 
     total_errors_str = (
-        _green("Success") if total_errors == 0 else _red(f"Error{'s' if total_errors > 1 else ''}")
+        _green("Success", suppress_colors) if total_errors == 0 else _red(f"Error{'s' if total_errors > 1 else ''}", suppress_colors)
     )
 
     summary.append(
         f"{total_subs_str:<{width_sub_name}} "
-        f"{_color_int(total_added):>{width_num_entries_added}} "
-        f"{_color_int(total_modified):>{width_num_entries_modified}} "
-        f"{_color_int(total_removed * -1):>{width_num_entries_removed}} "
+        f"{_color_int(total_added, suppress_colors):>{width_num_entries_added}} "
+        f"{_color_int(total_modified, suppress_colors):>{width_num_entries_modified}} "
+        f"{_color_int(total_removed * -1, suppress_colors):>{width_num_entries_removed}} "
         f"{total_entries:>{width_num_entries}} "
         f"{total_errors_str}"
     )

--- a/src/ytdl_sub/cli/output_summary.py
+++ b/src/ytdl_sub/cli/output_summary.py
@@ -59,8 +59,6 @@ def output_summary(subscriptions: List[Subscription], config: ConfigFile) -> Non
 
     suppress_colors = config.config_options.suppress_colors
 
-    logger.info(f"The suppress_colors option is {suppress_colors}")
-
     # Initialize totals to 0
     total_subs: int = len(subscriptions)
     total_subs_str = f"Total: {total_subs}"

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -61,7 +61,7 @@ class PersistLogsValidator(StrictDictValidator):
                 raise self._validation_exception(f"Invalid datetime string: {str(exc)}")
 
         self._keep_successful_logs = self._validate_key(
-            key="keep_successful_logs", validator=BoolValidator, default=True
+            key="keep_successful_logs", validator=StringValidator, default=True
         )
 
     @property
@@ -108,6 +108,7 @@ class ConfigOptions(StrictDictValidator):
         "ffprobe_path",
         "file_name_max_bytes",
         "experimental",
+        "suppress_colors",
     }
 
     def __init__(self, name: str, value: Any):
@@ -141,6 +142,9 @@ class ConfigOptions(StrictDictValidator):
         )
         self._file_name_max_bytes = self._validate_key(
             key="file_name_max_bytes", validator=IntValidator, default=MAX_FILE_NAME_BYTES
+        )
+        self._suppress_colors = self._validate_key_if_present(
+            key="suppress_colors", validator=BoolValidator, default=False
         )
 
     @property
@@ -235,6 +239,12 @@ class ConfigOptions(StrictDictValidator):
         """
         return self._ffprobe_path.value
 
+    @property
+    def suppress_colors(self) -> bool:
+        """
+        Flag to disable colors in the output summary
+        """
+        return self._suppress_colors.value
 
 class ConfigValidator(StrictDictValidator):
     _optional_keys = {"configuration", "presets"}

--- a/src/ytdl_sub/config/config_validator.py
+++ b/src/ytdl_sub/config/config_validator.py
@@ -61,7 +61,7 @@ class PersistLogsValidator(StrictDictValidator):
                 raise self._validation_exception(f"Invalid datetime string: {str(exc)}")
 
         self._keep_successful_logs = self._validate_key(
-            key="keep_successful_logs", validator=StringValidator, default=True
+            key="keep_successful_logs", validator=BoolValidator, default=True
         )
 
     @property


### PR DESCRIPTION
This is a small/probably unnecessary addition, but I needed output that didn't have colors added to the summary output (for parsing/display purposes) so I added a config option called suppress_colors. Then I use that in the _red, _green, etc functions in output_summary.py to only return the value if the flag is true.

I didn't know the best way to get the config object in output_summary, so I'm passing it in the call to output_summary from entrypoint. I'm sure this is not the way to do it.

Feel free to ignore this -- I'm probably the only one who needs it -- but since I wrote it already I figured I'd send it through