### PR TITLE
[FEATURE] Throw more actionable error if users supply the wrong type of url for TV show presets

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_by_date.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_by_date.yaml
@@ -37,12 +37,12 @@ presets:
   _tv_show_by_date:
     preset:
       - "_multi_url_bilateral"
-      - "_tv_show_collection_asserts"
+      - "_tv_show_by_date_asserts"
     overrides:
       avatar_uncropped_thumbnail_file_name: "{tv_show_poster_file_name}"
       banner_uncropped_thumbnail_file_name: "{tv_show_fanart_file_name}"
 
-  _tv_show_collection_asserts:
+  _tv_show_by_date_asserts:
     overrides:
       s01_url: ""
       s01_name: ""

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_by_date.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_by_date.yaml
@@ -35,10 +35,28 @@ presets:
 
   # TV show from one or more sources. Uses {url}'s avatar and banner as poster and fanart
   _tv_show_by_date:
-    preset: "_multi_url_bilateral"
+    preset:
+      - "_multi_url_bilateral"
+      - "_tv_show_collection_asserts"
     overrides:
       avatar_uncropped_thumbnail_file_name: "{tv_show_poster_file_name}"
       banner_uncropped_thumbnail_file_name: "{tv_show_fanart_file_name}"
+
+  _tv_show_collection_asserts:
+    overrides:
+      s01_url: ""
+      s01_name: ""
+      assert_not_collection: >-
+        {
+          %assert(
+            %and(
+              %not( %bool(s01_url) ),
+              %not( %bool(s01_name) )
+            ),
+            "Provided `s01_url` or `s01_name` variable to TV Show by Date preset when it expects `url`. Perhaps you meant to use the `TV Show Collection` preset?"
+          )
+        }
+          
 
 ####################################################################################################
 

--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
@@ -62,6 +62,7 @@ presets:
   _tv_show_collection:
     preset:
       - "_tv_show_collection_bilateral"
+      - "_tv_show_collection_asserts"
 
     download:
       - url: "{collection_season_1_url}"
@@ -1015,6 +1016,16 @@ presets:
         ytdl_options:
           playlist_items: "-1:0:-1"
 
+  _tv_show_collection_asserts:
+    overrides:
+      url: ""
+      assert_not_by_date: >-
+        {
+          %assert(
+            %not( %bool(url) ),
+            "Provided `url` to TV Show Collection preset when it expects `s01_url`. Perhaps you meant to use the `TV Show by Date` preset?"
+          )
+        }
 
 ####################################################################################################
 # DEPRECATED SEASON PRESETS

--- a/tests/unit/prebuilt_presets/test_tv_show_by_date.py
+++ b/tests/unit/prebuilt_presets/test_tv_show_by_date.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from ytdl_sub.script.utils.exceptions import UserThrownRuntimeError
+from ytdl_sub.subscriptions.subscription import Subscription
+
+
+class TestTvShowByDatePreset:
+
+    def test_s01_error_thrown(self, default_config):
+        with pytest.raises(
+            UserThrownRuntimeError,
+            match=re.escape(
+                "Provided `s01_url` or `s01_name` variable to TV Show by Date preset when it "
+                "expects `url`. Perhaps you meant to use the `TV Show Collection` preset?"
+            ),
+        ):
+            _ = Subscription.from_dict(
+                config=default_config,
+                preset_name="test",
+                preset_dict={
+                    "preset": "Jellyfin TV Show by Date",
+                    "overrides": {"tv_show_directory": "abc", "s01_url": "test"},
+                },
+            )

--- a/tests/unit/prebuilt_presets/test_tv_show_collection.py
+++ b/tests/unit/prebuilt_presets/test_tv_show_collection.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+
+from ytdl_sub.script.utils.exceptions import UserThrownRuntimeError
+from ytdl_sub.subscriptions.subscription import Subscription
+
+
+class TestTvShowCollectionPreset:
+
+    def test_url_error_thrown(self, default_config):
+        with pytest.raises(
+            UserThrownRuntimeError,
+            match=re.escape(
+                "Provided `url` to TV Show Collection preset when it expects `s01_url`. "
+                "Perhaps you meant to use the `TV Show by Date` preset?"
+            ),
+        ):
+            _ = Subscription.from_dict(
+                config=default_config,
+                preset_name="test",
+                preset_dict={
+                    "preset": "Jellyfin TV Show Collection",
+                    "overrides": {"tv_show_directory": "abc", "url": "test"},
+                },
+            )


### PR DESCRIPTION
Dont let users supply `url` for TV Show Collection presets, or `s01_url` for TV Show by Date presets.