### PR TITLE
[FEATURE] Ability to customize date used for deleting old files

### DIFF
--- a/docs/source/config_reference/plugins.rst
+++ b/docs/source/config_reference/plugins.rst
@@ -640,6 +640,8 @@ Defines where to output files and thumbnails after all post-processing has compl
          maintain_download_archive: True
          keep_files_before: now
          keep_files_after: 19000101
+         keep_max_files: 1000
+         keep_files_date_eval: "{upload_date_standardized}"
 
 ``download_archive_name``
 
@@ -688,6 +690,16 @@ Defines where to output files and thumbnails after all post-processing has compl
   Only keeps files that are uploaded before this datetime. By default, ytdl-sub will keep
   files before ``now``, which implies all files. Can be used in conjunction with
   ``keep_max_files``.
+
+
+``keep_files_date_eval``
+
+:expected type: str
+:description:
+    Uses this standardized date in the form of YYYY-MM-DD to record in the
+    download archive for a given entry. Subsequently, uses this value to
+    perform evaluation for keep_files_before/after and keep_max_files. Defaults
+    to the entry's upload_date_standardized variable.
 
 
 ``keep_max_files``

--- a/docs/source/config_reference/scripting/entry_variables.rst
+++ b/docs/source/config_reference/scripting/entry_variables.rst
@@ -659,3 +659,9 @@ ytdl_sub_input_url_index
 :type: ``Integer``
 :description:
   The index of the input URL as defined in the subscription, top-most being the 0th index.
+
+ytdl_sub_keep_files_date_eval
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:type: ``String``
+:description:
+  The standardized date variable supplied in ``output_options.keep_files_date_eval``.

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -8,13 +8,13 @@ from ytdl_sub.validators.file_path_validators import OverridesStringFormatterFil
 from ytdl_sub.validators.file_path_validators import StringFormatterFileNameValidator
 from ytdl_sub.validators.strict_dict_validator import StrictDictValidator
 from ytdl_sub.validators.string_datetime import StringDatetimeValidator
-from ytdl_sub.validators.string_formatter_validators import OverridesIntegerFormatterValidator
+from ytdl_sub.validators.string_formatter_validators import OverridesIntegerFormatterValidator, \
+    OverridesStandardizedDateValidator
 from ytdl_sub.validators.string_formatter_validators import OverridesStringFormatterValidator
 from ytdl_sub.validators.string_formatter_validators import StringFormatterValidator
 from ytdl_sub.validators.string_formatter_validators import (
     UnstructuredOverridesDictFormatterValidator,
 )
-from ytdl_sub.validators.string_select_validator import StringSelectValidator
 from ytdl_sub.validators.validators import BoolValidator
 
 
@@ -65,20 +65,6 @@ class YTDLOptions(UnstructuredOverridesDictFormatterValidator):
 # Disable for proper docstring formatting
 # pylint: disable=line-too-long
 
-class KeepFilesDateEvalValidator(StringSelectValidator):
-    UPLOAD_DATE = "upload_date"
-    RELEASE_DATE = "release_date"
-    _expected_value_type_name = "keep_files_date_eval"
-    _select_values = {UPLOAD_DATE, RELEASE_DATE}
-
-    @property
-    def is_upload_date(self) -> bool:
-        return self.value == self.UPLOAD_DATE
-
-    @property
-    def is_release_date(self) -> bool:
-        return self.value == self.RELEASE_DATE
-
 
 class OutputOptions(StrictDictValidator):
     """
@@ -116,7 +102,7 @@ class OutputOptions(StrictDictValidator):
         "keep_files_before",
         "keep_files_after",
         "keep_max_files",
-        "keep_files_date_eval",
+        "download_archive_standardized_date",
     }
 
     @classmethod
@@ -174,8 +160,8 @@ class OutputOptions(StrictDictValidator):
         self._keep_max_files = self._validate_key_if_present(
             "keep_max_files", OverridesIntegerFormatterValidator
         )
-        self._keep_files_date_eval = self._validate_key_if_present(
-            "keep_files_date_eval", KeepFilesDateEvalValidator, default=KeepFilesDateEvalValidator.UPLOAD_DATE
+        self._entry_date_eval = self._validate_key_if_present(
+            "entry_date_eval", OverridesStandardizedDateValidator
         )
 
         if (
@@ -294,14 +280,16 @@ class OutputOptions(StrictDictValidator):
         return self._keep_files_after
 
     @property
-    def keep_files_date_eval(self) -> Optional[KeepFilesDateEvalValidator]:
+    def entry_date_eval(self) -> Optional[OverridesStandardizedDateValidator]:
         """
         :expected type: str
         :description:
-            When using keep_files_before/after, uses the date set in this field for evaluation.
-            Supports ``upload_date``, ``release_date``, defaults to ``upload_date``.
+            Uses this standardized date in the form of YYYY-MM-DD to record in the
+            download archive for a given entry. Subsequently, uses this value to
+            perform evaluation for keep_files_before/after and keep_max_files. Defaults
+            to the entry's upload_date_standardized variable.
         """
-        return self._keep_files_date_eval
+        return self._entry_date_eval
 
     @property
     def keep_max_files(self) -> Optional[OverridesIntegerFormatterValidator]:

--- a/src/ytdl_sub/config/preset_options.py
+++ b/src/ytdl_sub/config/preset_options.py
@@ -106,7 +106,7 @@ class OutputOptions(OptionsDictValidator):
         "keep_files_after",
         "keep_max_files",
         "download_archive_standardized_date",
-        "entry_date_eval",
+        "keep_files_date_eval",
     }
 
     @classmethod
@@ -164,10 +164,10 @@ class OutputOptions(OptionsDictValidator):
         self._keep_max_files = self._validate_key_if_present(
             "keep_max_files", OverridesIntegerFormatterValidator
         )
-        self._entry_date_eval = self._validate_key(
-            "entry_date_eval",
+        self._keep_files_date_eval = self._validate_key(
+            "keep_files_date_eval",
             StandardizedDateValidator,
-            default=f"{{{v.upload_date_standardized.variable_name}}}"
+            default=f"{{{v.upload_date_standardized.variable_name}}}",
         )
 
         if (
@@ -286,7 +286,7 @@ class OutputOptions(OptionsDictValidator):
         return self._keep_files_after
 
     @property
-    def entry_date_eval(self) -> StandardizedDateValidator:
+    def keep_files_date_eval(self) -> StandardizedDateValidator:
         """
         :expected type: str
         :description:
@@ -295,7 +295,7 @@ class OutputOptions(OptionsDictValidator):
             perform evaluation for keep_files_before/after and keep_max_files. Defaults
             to the entry's upload_date_standardized variable.
         """
-        return self._entry_date_eval
+        return self._keep_files_date_eval
 
     @property
     def keep_max_files(self) -> Optional[OverridesIntegerFormatterValidator]:

--- a/src/ytdl_sub/config/validators/variable_validation.py
+++ b/src/ytdl_sub/config/validators/variable_validation.py
@@ -57,13 +57,14 @@ def _add_dummy_overrides(overrides: Overrides) -> Dict[str, str]:
 
 
 def _get_added_and_modified_variables(
-    plugins: PresetPlugins, downloader_options: MultiUrlValidator
+    plugins: PresetPlugins, downloader_options: MultiUrlValidator, output_options: OutputOptions
 ) -> Iterable[Tuple[OptionsValidator, Set[str], Set[str]]]:
     """
     Iterates and returns the plugin options, added variables, modified variables
     """
     options: List[OptionsValidator] = plugins.plugin_options
     options.append(downloader_options)
+    options.append(output_options)
 
     for plugin_options in options:
         added_variables: Set[str] = set()
@@ -117,6 +118,7 @@ class VariableValidation:
         ) in _get_added_and_modified_variables(
             plugins=self.plugins,
             downloader_options=self.downloader_options,
+            output_options=self.output_options,
         ):
 
             for added_variable in added_variables:
@@ -182,6 +184,9 @@ class VariableValidation:
 
         self._add_variables(PluginOperation.DOWNLOADER, options=self.downloader_options)
         self._add_subscription_override_variables()
+
+        # Always add output options first
+        self._add_variables(PluginOperation.MODIFY_ENTRY_METADATA, options=self.output_options)
 
         # Metadata variables to be added
         for plugin_options in PluginMapping.order_options_by(

--- a/src/ytdl_sub/entries/script/variable_definitions.py
+++ b/src/ytdl_sub/entries/script/variable_definitions.py
@@ -824,10 +824,10 @@ class YtdlSubVariableDefinitions(ABC):
         )
 
     @cached_property
-    def ytdl_sub_entry_date_eval(self: "VariableDefinitions") -> StringVariable:
+    def ytdl_sub_keep_files_date_eval(self: "VariableDefinitions") -> StringVariable:
         """
         :description:
-          The standardized date variable supplied in ``output_options.entry_date_eval``
+          The standardized date variable supplied in ``output_options.keep_files_date_eval``.
         """
         return StringVariable(
             variable_name="ytdl_sub_entry_date_eval",
@@ -1132,7 +1132,7 @@ class VariableDefinitions(
             self.ytdl_sub_input_url,
             self.ytdl_sub_input_url_index,
             self.ytdl_sub_input_url_count,
-            self.ytdl_sub_entry_date_eval,
+            self.ytdl_sub_keep_files_date_eval,
         }
 
     @cache

--- a/src/ytdl_sub/entries/script/variable_definitions.py
+++ b/src/ytdl_sub/entries/script/variable_definitions.py
@@ -823,6 +823,14 @@ class YtdlSubVariableDefinitions(ABC):
             variable_name="upload_date_index_reversed_padded", pad=2
         )
 
+    @cached_property
+    def ytdl_sub_entry_date_eval(self: "VariableDefinitions") -> StringVariable:
+        """
+        :description:
+          The standardized
+        """
+        return StringVariable(variable_name="ytdl_sub_input_url", definition="{ %string('') }")
+
 
 class EntryVariableDefinitions(ABC):
     @cached_property

--- a/src/ytdl_sub/entries/script/variable_definitions.py
+++ b/src/ytdl_sub/entries/script/variable_definitions.py
@@ -827,9 +827,12 @@ class YtdlSubVariableDefinitions(ABC):
     def ytdl_sub_entry_date_eval(self: "VariableDefinitions") -> StringVariable:
         """
         :description:
-          The standardized
+          The standardized date variable supplied in ``output_options.entry_date_eval``
         """
-        return StringVariable(variable_name="ytdl_sub_input_url", definition="{ %string('') }")
+        return StringVariable(
+            variable_name="ytdl_sub_entry_date_eval",
+            definition=f"{{%string({self.upload_date_standardized.variable_name})}}",
+        )
 
 
 class EntryVariableDefinitions(ABC):
@@ -1129,6 +1132,7 @@ class VariableDefinitions(
             self.ytdl_sub_input_url,
             self.ytdl_sub_input_url_index,
             self.ytdl_sub_input_url_count,
+            self.ytdl_sub_entry_date_eval,
         }
 
     @cache

--- a/src/ytdl_sub/subscriptions/base_subscription.py
+++ b/src/ytdl_sub/subscriptions/base_subscription.py
@@ -31,7 +31,6 @@ def _initialize_download_archive(
         file_name=overrides.apply_formatter(output_options.download_archive_name),
         working_directory=working_directory,
         output_directory=output_directory,
-        entry_date_eval=output_options.entry_date_eval,
         migrated_file_name=migrated_file_name,
     ).reinitialize(dry_run=True)
 

--- a/src/ytdl_sub/subscriptions/base_subscription.py
+++ b/src/ytdl_sub/subscriptions/base_subscription.py
@@ -31,6 +31,7 @@ def _initialize_download_archive(
         file_name=overrides.apply_formatter(output_options.download_archive_name),
         working_directory=working_directory,
         output_directory=output_directory,
+        entry_date_eval=output_options.keep_files_date_eval,
         migrated_file_name=migrated_file_name,
     ).reinitialize(dry_run=True)
 

--- a/src/ytdl_sub/subscriptions/base_subscription.py
+++ b/src/ytdl_sub/subscriptions/base_subscription.py
@@ -31,7 +31,7 @@ def _initialize_download_archive(
         file_name=overrides.apply_formatter(output_options.download_archive_name),
         working_directory=working_directory,
         output_directory=output_directory,
-        entry_date_eval=output_options.keep_files_date_eval,
+        entry_date_eval=output_options.entry_date_eval,
         migrated_file_name=migrated_file_name,
     ).reinitialize(dry_run=True)
 

--- a/src/ytdl_sub/subscriptions/subscription_download.py
+++ b/src/ytdl_sub/subscriptions/subscription_download.py
@@ -221,12 +221,16 @@ class SubscriptionDownload(BaseSubscription, ABC):
 
         # Inject OutputOption variables here
         entry.add(
-            {VARIABLES.ytdl_sub_entry_date_eval: self.output_options.entry_date_eval.format_string}
+            {
+                VARIABLES.ytdl_sub_entry_date_eval: (
+                    self.output_options.keep_files_date_eval.format_string
+                )
+            }
         )
 
         # Run it to make sure it's actually a standardized date
         _ = self.overrides.apply_formatter(
-            formatter=self.output_options.entry_date_eval, entry=entry
+            formatter=self.output_options.keep_files_date_eval, entry=entry
         )
 
         for plugin in PluginMapping.order_plugins_by(

--- a/src/ytdl_sub/subscriptions/subscription_download.py
+++ b/src/ytdl_sub/subscriptions/subscription_download.py
@@ -222,7 +222,7 @@ class SubscriptionDownload(BaseSubscription, ABC):
         # Inject OutputOption variables here
         entry.add(
             {
-                VARIABLES.ytdl_sub_entry_date_eval: (
+                VARIABLES.ytdl_sub_keep_files_date_eval: (
                     self.output_options.keep_files_date_eval.format_string
                 )
             }

--- a/src/ytdl_sub/subscriptions/subscription_download.py
+++ b/src/ytdl_sub/subscriptions/subscription_download.py
@@ -17,6 +17,7 @@ from ytdl_sub.downloaders.source_plugin import SourcePlugin
 from ytdl_sub.downloaders.url.downloader import MultiUrlDownloader
 from ytdl_sub.downloaders.ytdl_options_builder import YTDLOptionsBuilder
 from ytdl_sub.entries.entry import Entry
+from ytdl_sub.entries.script.variable_definitions import VARIABLES
 from ytdl_sub.subscriptions.base_subscription import BaseSubscription
 from ytdl_sub.subscriptions.subscription_ytdl_options import SubscriptionYTDLOptions
 from ytdl_sub.utils.datetime import to_date_range
@@ -215,9 +216,19 @@ class SubscriptionDownload(BaseSubscription, ABC):
         FileHandler.delete(entry.get_download_thumbnail_path())
         FileHandler.delete(entry.get_download_info_json_path())
 
-    @classmethod
-    def _preprocess_entry(cls, plugins: List[Plugin], entry: Entry) -> Optional[Entry]:
+    def _preprocess_entry(self, plugins: List[Plugin], entry: Entry) -> Optional[Entry]:
         maybe_entry: Optional[Entry] = entry
+
+        # Inject OutputOption variables here
+        entry.add(
+            {VARIABLES.ytdl_sub_entry_date_eval: self.output_options.entry_date_eval.format_string}
+        )
+
+        # Run it to make sure it's actually a standardized date
+        _ = self.overrides.apply_formatter(
+            formatter=self.output_options.entry_date_eval, entry=entry
+        )
+
         for plugin in PluginMapping.order_plugins_by(
             plugins, PluginOperation.MODIFY_ENTRY_METADATA
         ):

--- a/src/ytdl_sub/validators/string_formatter_validators.py
+++ b/src/ytdl_sub/validators/string_formatter_validators.py
@@ -74,6 +74,20 @@ class StringFormatterValidator(StringValidator):
         return resolved
 
 
+class StandardizedDateValidator(StringFormatterValidator):
+    _expected_value_type_name = "standardized_date"
+
+    def post_process(self, resolved: str) -> str:
+        try:
+            datetime.strptime(resolved, "%Y-%m-%d")
+        except ValueError as exc:
+            raise self._validation_exception(
+                f"Expected a standardized date in the form of YYYY-MM-DD, but received '{resolved}'"
+            ) from exc
+
+        return resolved
+
+
 # pylint: disable=line-too-long
 class OverridesStringFormatterValidator(StringFormatterValidator):
     """
@@ -103,19 +117,6 @@ class OverridesIntegerFormatterValidator(OverridesStringFormatterValidator):
 
         return resolved
 
-
-class OverridesStandardizedDateValidator(OverridesStringFormatterValidator):
-    _expected_value_type_name = "standardized_date"
-
-    def post_process(self, resolved: str) -> str:
-        try:
-            datetime.strptime(resolved, "%Y-%m-%d")
-        except ValueError as exc:
-            raise self._validation_exception(
-                f"Expected a standardized date in the form of YYYY-MM-DD, but received '{resolved}'"
-            ) from exc
-
-        return resolved
 
 class OverridesBooleanFormatterValidator(OverridesStringFormatterValidator):
     _expected_value_type_name = "boolean"

--- a/src/ytdl_sub/validators/string_formatter_validators.py
+++ b/src/ytdl_sub/validators/string_formatter_validators.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict
 from typing import Set
 from typing import Union
@@ -102,6 +103,19 @@ class OverridesIntegerFormatterValidator(OverridesStringFormatterValidator):
 
         return resolved
 
+
+class OverridesStandardizedDateValidator(OverridesStringFormatterValidator):
+    _expected_value_type_name = "standardized_date"
+
+    def post_process(self, resolved: str) -> str:
+        try:
+            datetime.strptime(resolved, "%Y-%m-%d")
+        except ValueError as exc:
+            raise self._validation_exception(
+                f"Expected a standardized date in the form of YYYY-MM-DD, but received '{resolved}'"
+            ) from exc
+
+        return resolved
 
 class OverridesBooleanFormatterValidator(OverridesStringFormatterValidator):
     _expected_value_type_name = "boolean"

--- a/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
+++ b/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
@@ -75,7 +75,7 @@ class DownloadMapping:
         DownloadMapping for the entry
         """
         return DownloadMapping(
-            upload_date=entry.get(v.ytdl_sub_entry_date_eval, str),
+            upload_date=entry.get(v.ytdl_sub_keep_files_date_eval, str),
             extractor=entry.download_archive_extractor,
             file_names=set(),
         )

--- a/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
+++ b/src/ytdl_sub/ytdl_additions/enhanced_download_archive.py
@@ -13,6 +13,7 @@ from typing import Set
 from yt_dlp import DateRange
 from yt_dlp.utils import make_archive_id
 
+from ytdl_sub.config.preset_options import KeepFilesDateEvalValidator
 from ytdl_sub.entries.entry import Entry
 from ytdl_sub.entries.entry import ytdl_sub_split_by_chapters_parent_uid
 from ytdl_sub.entries.script.variable_definitions import VARIABLES
@@ -63,19 +64,21 @@ class DownloadMapping:
         )
 
     @classmethod
-    def from_entry(cls, entry: Entry) -> "DownloadMapping":
+    def from_entry(cls, entry: Entry, entry_date: str) -> "DownloadMapping":
         """
         Parameters
         ----------
         entry
             Entry to create a download mapping for
+        entry_date:
+            Date to use for the entry
 
         Returns
         -------
         DownloadMapping for the entry
         """
         return DownloadMapping(
-            upload_date=entry.get(v.upload_date_standardized, str),
+            upload_date=entry_date,
             extractor=entry.download_archive_extractor,
             file_names=set(),
         )
@@ -151,19 +154,25 @@ class DownloadArchive:
 class DownloadMappings:
     _strptime_format = "%Y-%m-%d"
 
-    def __init__(self):
+    def __init__(self, entry_date_eval: KeepFilesDateEvalValidator):
         """
         Initializes an empty mapping
+
+        entry_date_eval
+            Which date to use for download mapping logging
         """
+        self._entry_date_eval = entry_date_eval
         self._entry_mappings: Dict[str, DownloadMapping] = {}
 
     @classmethod
-    def from_file(cls, json_file_path: str) -> "DownloadMappings":
+    def from_file(cls, json_file_path: str, entry_date_eval: KeepFilesDateEvalValidator) -> "DownloadMappings":
         """
         Parameters
         ----------
         json_file_path
             Path to a json file that contains download mappings
+        entry_date_eval
+            Which date to use for download mapping logging
 
         Returns
         -------
@@ -177,7 +186,7 @@ class DownloadMappings:
                 mapping_dict=entry_mappings_json[uid]
             )
 
-        download_mappings = DownloadMappings()
+        download_mappings = DownloadMappings(entry_date_eval=entry_date_eval)
         download_mappings._entry_mappings = entry_mappings_json
         return download_mappings
 
@@ -218,7 +227,6 @@ class DownloadMappings:
             Entry that this file belongs to
         entry_file_path
             Relative path to the file that lives in the output directory
-
         Returns
         -------
         self
@@ -228,7 +236,14 @@ class DownloadMappings:
             uid = parent_uid
 
         if uid not in self.entry_ids:
-            self._entry_mappings[uid] = DownloadMapping.from_entry(entry=entry)
+            if self._entry_date_eval.is_upload_date:
+                entry_date = entry.get(v.upload_date_standardized, str)
+            elif self._entry_date_eval.is_release_date:
+                entry_date = entry.get(v.release_date_standardized, str)
+            else:
+                raise AssertionError("Unsupported entry_date_eval. Should not reach.")
+
+            self._entry_mappings[uid] = DownloadMapping.from_entry(entry=entry, entry_date=entry_date)
 
         self._entry_mappings[uid].file_names.add(entry_file_path)
         return self
@@ -370,7 +385,7 @@ class EnhancedDownloadArchive:
 
     @classmethod
     def _maybe_load_download_mappings(
-        cls, mapping_file_path: str, migrated_mapping_file_path: Optional[str]
+        cls, mapping_file_path: str, migrated_mapping_file_path: Optional[str], entry_date_eval: KeepFilesDateEvalValidator
     ) -> DownloadMappings:
         """
         Tries to load download mappings if a file exists. Otherwise returns empty mappings.
@@ -382,21 +397,22 @@ class EnhancedDownloadArchive:
                     "`output_options.migrated_download_archive` to "
                     "`output_options.download_archive`"
                 )
-                return DownloadMappings.from_file(migrated_mapping_file_path)
+                return DownloadMappings.from_file(json_file_path=migrated_mapping_file_path, entry_date_eval=entry_date_eval)
 
             logger.warning(
                 "MIGRATION DETECTED, will write archive file to %s", migrated_mapping_file_path
             )
 
         if os.path.isfile(mapping_file_path):
-            return DownloadMappings.from_file(json_file_path=mapping_file_path)
-        return DownloadMappings()
+            return DownloadMappings.from_file(json_file_path=mapping_file_path, entry_date_eval=entry_date_eval)
+        return DownloadMappings(entry_date_eval=entry_date_eval)
 
     def __init__(
         self,
         file_name: str,
         working_directory: str,
         output_directory: str,
+        entry_date_eval: KeepFilesDateEvalValidator,
         dry_run: bool = False,
         migrated_file_name: Optional[str] = None,
     ):
@@ -404,7 +420,8 @@ class EnhancedDownloadArchive:
         self._file_handler = FileHandler(
             working_directory=working_directory, output_directory=output_directory, dry_run=dry_run
         )
-        self._download_mapping = DownloadMappings()  # gets reinitialized
+        self._entry_date_eval = entry_date_eval
+        self._download_mapping = DownloadMappings(entry_date_eval=entry_date_eval)  # gets reinitialized
         self._migrated_file_name = migrated_file_name
 
         self.num_entries_added: int = 0
@@ -442,6 +459,7 @@ class EnhancedDownloadArchive:
         self._download_mapping = self._maybe_load_download_mappings(
             mapping_file_path=self._output_file_path,
             migrated_mapping_file_path=self._migrated_file_path,
+            entry_date_eval=self._entry_date_eval,
         )
         return self
 


### PR DESCRIPTION
Implements https://github.com/jmbannon/ytdl-sub/issues/1182

Adds the ability to change the `keep_files_date_eval` (traditionally upload_date_standardized) to any date, so long as its in the form of YYYY-MM-DD.

Will be able to use this to have episodes named and maintained with release_date instead of upload_date.