### PR TITLE
fix(throttle): Less finger-printable request delay

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/helpers/throttle_protection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/helpers/throttle_protection.yaml
@@ -14,8 +14,15 @@ presets:
           )
         }
       sleep_per_request_s:
-        min: 3.5
-        max: 3.5
+        # yt-dlp processes eath request synchronously, so it's intrinsic delay between
+        # requests already represent a maximum close to real app/client behavior in the
+        # field. Add a small additional margin matching the example values from yt-dlp
+        # to be conservative:
+        max: 0.75
+        # Not used at time of writing, but choose a value that would mimic real
+        # app/client behavior in the field. The next request is usually sent right away
+        # if processing the previous request is done asynchronously:
+        min: 0.0
       sleep_per_download_s:
         min: 13.8
         max: 28.4


### PR DESCRIPTION
Following [discussion about the previous preset
delay](https://discord.com/channels/994270357957648404/994270357957648408/1405705039649046589), we weren't able to find a reason for it and there was agreement that the example value from yt-dlp is more sensible.

While we're at it, also set a default `min:` value that would probably be sensible if it were to be used in the future.

Finally, capture the reasoning behind the new preset values in comments to make the reference documentation more helpful to new users in the future.