### PR TITLE
fix(docker): Missing cron script stderr output

### DIFF
--- a/docker/root/custom-cont-init.d/defaults
+++ b/docker/root/custom-cont-init.d/defaults
@@ -33,7 +33,7 @@ if [ "$CRON_SCHEDULE" != "" ] ; then
     echo '#!/bin/bash' > "$CRON_WRAPPER_SCRIPT"
     echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$CRON_WRAPPER_SCRIPT"
     echo "cd \"$DEFAULT_WORKSPACE\"" >> "$CRON_WRAPPER_SCRIPT"
-    echo ". \"$CRON_SCRIPT\" | tee -a \"$LOGS_TO_STDOUT\"" >> "$CRON_WRAPPER_SCRIPT"
+    echo ". \"$CRON_SCRIPT\" |& tee -a \"$LOGS_TO_STDOUT\"" >> "$CRON_WRAPPER_SCRIPT"
     chmod +x "$CRON_WRAPPER_SCRIPT"
     chown abc:abc "$CRON_WRAPPER_SCRIPT"
 


### PR DESCRIPTION
I'm not actually sure this is needed or correct and I haven't tested it, but just pushing a commit was an easy way to demonstrate my question.

If I'm reading correctly the `/config/.cron_wrapper` script generated by starting the container, then the `stderr` output of the wrapped script will *not* be included in `/config/.cron.log` and will essentially be lost. Am I correct in that?