### PR TITLE
[FEATURE] Apply entry throttle protection sleep post-completion

### DIFF
--- a/src/ytdl_sub/config/plugin/plugin.py
+++ b/src/ytdl_sub/config/plugin/plugin.py
@@ -119,6 +119,17 @@ class Plugin(BasePlugin[OptionsValidatorT], Generic[OptionsValidatorT], ABC):
         """
         return None
 
+    def post_completion_entry(self, file_metadata: FileMetadata) -> None:
+        """
+        After the entry file is moved to its final location, run this hook.
+
+        Parameters
+        ----------
+        file_metadata
+            Metadata about the completed entry's file download
+        """
+        return None
+
     def post_process_subscription(self):
         """
         After all downloaded files have been post-processed, apply a subscription-wide post process

--- a/src/ytdl_sub/config/plugin/plugin_mapping.py
+++ b/src/ytdl_sub/config/plugin/plugin_mapping.py
@@ -92,6 +92,12 @@ class PluginMapping:
         EmbedThumbnailPlugin,
     ]
 
+    _ORDER_POST_COMPLETION: List[Type[Plugin]] = [
+        # Throttle protection should always be last
+        # to not sleep over other logic
+        ThrottleProtectionPlugin
+    ]
+
     @classmethod
     def _order_by(
         cls, plugin_types: List[Type[Plugin]], operation: PluginOperation
@@ -102,6 +108,8 @@ class PluginMapping:
             ordering = cls._ORDER_MODIFY_ENTRY
         elif operation == PluginOperation.POST_PROCESS:
             ordering = cls._ORDER_POST_PROCESS
+        elif operation == PluginOperation.POST_COMPLETION:
+            ordering = cls._ORDER_POST_COMPLETION
         else:
             raise ValueError("PluginOperation does not support ordering")
 

--- a/src/ytdl_sub/config/plugin/plugin_operation.py
+++ b/src/ytdl_sub/config/plugin/plugin_operation.py
@@ -6,3 +6,4 @@ class PluginOperation(Enum):
     MODIFY_ENTRY_METADATA = 0
     MODIFY_ENTRY = 1
     POST_PROCESS = 2
+    POST_COMPLETION = 3

--- a/src/ytdl_sub/subscriptions/subscription_download.py
+++ b/src/ytdl_sub/subscriptions/subscription_download.py
@@ -259,6 +259,9 @@ class SubscriptionDownload(BaseSubscription, ABC):
         if self.maintain_download_archive:
             self.download_archive.save_download_mappings()
 
+        for plugin in PluginMapping.order_plugins_by(plugins, PluginOperation.POST_COMPLETION):
+            plugin.post_completion_entry(file_metadata=entry_metadata)
+
     def _process_entry(
         self, plugins: List[Plugin], dry_run: bool, entry: Entry, entry_metadata: FileMetadata
     ) -> None:


### PR DESCRIPTION
Closes https://github.com/jmbannon/ytdl-sub/issues/1294

Applies entry sleep per download *after* the download is fully complete and moved to the output folder.