### PR TITLE
[BACKEND] Make resolution print debug-level

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/helpers/throttle_protection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/helpers/throttle_protection.yaml
@@ -43,7 +43,8 @@ presets:
               "Resolution assert is enabled, will fail on low-quality video downloads and presume throttle. Disable using the override variable `enable_resolution_assert: False`",
               "Resolution assert is disabled. Use at your own risk!"
             ),
-            enable_resolution_assert
+            enable_resolution_assert,
+            -1
           )
         }
       resolution_readable: "{width}x{height}"

--- a/tests/integration/plugins/test_throttle_protection.py
+++ b/tests/integration/plugins/test_throttle_protection.py
@@ -237,7 +237,7 @@ class TestResolutionAssert:
                 "Resolution assert is enabled, will fail on low-quality video downloads and presume throttle. "
                 "Disable using the override variable `enable_resolution_assert: False`"
             ),
-            log_level="info",
+            log_level="debug",
             expected_occurrences=1,
         ):
             subscription = Subscription.from_dict(

--- a/tests/integration/plugins/test_throttle_protection.py
+++ b/tests/integration/plugins/test_throttle_protection.py
@@ -205,7 +205,7 @@ class TestResolutionAssert:
         with assert_logs(
             logger=script_print_logger,
             expected_message="Resolution assert is disabled. Use at your own risk!",
-            log_level="info",
+            log_level="debug",
             expected_occurrences=1,
         ):
             _ = Subscription.from_dict(


### PR DESCRIPTION
```
Resolution assert is enabled, will fail on low-quality video downloads and presume throttle. Disable using the override variable `enable_resolution_assert: False
```
Spams during the initialization phase. Ideally, we should only print this once the subscription has begun downloading. Perhaps via a `print` plugin? Either way, set this to debug log level.