### PR TITLE
fix issue 1202 - double logging of cron job

### DIFF
--- a/docker/root/custom-cont-init.d/defaults
+++ b/docker/root/custom-cont-init.d/defaults
@@ -33,7 +33,7 @@ if [ "$CRON_SCHEDULE" != "" ] ; then
     echo '#!/bin/bash' > "$CRON_WRAPPER_SCRIPT"
     echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$CRON_WRAPPER_SCRIPT"
     echo "cd \"$DEFAULT_WORKSPACE\"" >> "$CRON_WRAPPER_SCRIPT"
-    echo ". \"$CRON_SCRIPT\" | tee -a \"$LOGS_TO_STDOUT\"" >> "$CRON_WRAPPER_SCRIPT"
+    echo ". \"$CRON_SCRIPT\" >> \"$LOGS_TO_STDOUT\" 2>&1" >> "$CRON_WRAPPER_SCRIPT"
     chmod +x "$CRON_WRAPPER_SCRIPT"
     chown abc:abc "$CRON_WRAPPER_SCRIPT"
 


### PR DESCRIPTION
The double logging (seen in Portainer, for example) is caused by the erroneous contents of `/config/.cron_wrapper`

```txt
#!/bin/bash
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
cd "/config"
. "/config/cron" | tee -a "/config/.cron.log"
```

As mentioned in https://github.com/jmbannon/ytdl-sub/issues/1202, the container is (already) logging `/config/.cron.log`, by way of the `LOGS_TO_STDOUT="${DEFAULT_WORKSPACE}/.cron.log"` line, set in the Dockerfile

In order to fix the double logging issue, one of them should go. As the "LSIO docker-mod's `LOGS_TO_STDOUT`" method is used in the other Dockerfile variants, the best place to remedy this is in the  `/config/.cron_wrapper` file, which I believe is not producing the intended results anyway...

The `/config/cron | tee -a /config/.cron.log` pipeline appends the output of the command `/config/cron` to the file `/config/.cron.log` **while also** printing that same output to the terminal (stdout). stdout is what's getting logged in the Portainer logs **AND** the container is also being told to log the contents of `/config/.cron.log` aswell, by way of the LSIO docker-mod's `LOGS_TO_STDOUT` env. Hence, double logging.

Rather than use `tee`, the command should just redirect stdout to the file. For example:

`/config/cron >> "/config/.cron.log"`

or better still, to capture stderr as well (as proposed in the PR)

`/config/cron >> "/config/.cron.log" 2>&1`

Hope that helps clarify things 🤞