### PR TITLE
[DOCKER] Make default paths same as docker defaults

### DIFF
--- a/docker/root/defaults/config.yaml
+++ b/docker/root/defaults/config.yaml
@@ -19,4 +19,4 @@ configuration:
   # Avoid unnecessarily long large file renames, set this to a path on the same
   # filesystem as the destination for downloaded files in the `overrides: /
   # *_directory:` paths:
-  working_directory: "/media/Library/tmp/.ytdl-sub-working-directory"
+  working_directory: ".ytdl-sub-working-directory"

--- a/docker/root/defaults/subscriptions.yaml
+++ b/docker/root/defaults/subscriptions.yaml
@@ -6,13 +6,13 @@
 __preset__:
   overrides:
     # Root folder of all ytdl-sub TV Shows
-    tv_show_directory: "/media/Library/Videos/Series"
+    tv_show_directory: "/tv_shows"
 
     # Root folder of all ytdl-sub Music
-    music_directory: "/media/Library/Music"
+    music_directory: "/music"
 
     # Root folder of all ytdl-sub Music Videos
-    music_video_directory: "/media/Library/Videos/Music"
+    music_video_directory: "/music_videos"
 
     # For 'Only Recent' preset, only keep vids within this range and limit
     # only_recent_date_range: "2months"

--- a/docs/source/guides/getting_started/first_config.rst
+++ b/docs/source/guides/getting_started/first_config.rst
@@ -15,7 +15,7 @@ Below is a common configuration:
   :linenos:
 
   configuration:
-    working_directory: "/media/Library/tmp/.ytdl-sub-working-directory"
+    working_directory: ".ytdl-sub-working-directory"
 
   presets:
     TV Show:
@@ -37,7 +37,7 @@ Below is a common configuration:
            max: 36
 
       overrides:
-        tv_show_directory: "/media/Library/Videos/Series"
+        tv_show_directory: "/tv_shows"
 
     TV Show Only Recent:
       preset:
@@ -59,7 +59,7 @@ filesystem as your library in the ``overrides: / *_directory:`` paths:
   :lineno-start: 1
 
   configuration:
-    working_directory: "/media/Library/tmp/.ytdl-sub-working-directory"
+    working_directory: ".ytdl-sub-working-directory"
 
 
 Preset Section

--- a/src/ytdl_sub/config/defaults.py
+++ b/src/ytdl_sub/config/defaults.py
@@ -22,7 +22,7 @@ if IS_WINDOWS:
 
     MAX_FILE_NAME_BYTES = 255
 else:
-    DEFAULT_LOCK_DIRECTORY = "/tmp"
+    DEFAULT_LOCK_DIRECTORY = ".ytdl-sub-lock"
     DEFAULT_FFMPEG_PATH = os.getenv(
         "YTDL_SUB_FFMPEG_PATH", _existing_path("/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg")
     )

--- a/src/ytdl_sub/utils/file_lock.py
+++ b/src/ytdl_sub/utils/file_lock.py
@@ -45,6 +45,7 @@ else:
         )
 
         try:
+            os.makedirs(os.path.dirname(lock_file_path), exist_ok=True)
             lock_file = open(lock_file_path, "w", encoding="utf-8")
         except FileNotFoundError as exc:
             # pylint: disable=line-too-long


### PR DESCRIPTION
Changes documentation and default configs to use the `/tv_shows` default path shown in the docker compose setup.
Also changes working directory and file lock directory to not be in /tmp, which often causes permission issues.