### PR TITLE
[DOCKER] Env variable to update yt-dlp on start

### DIFF
--- a/docker/root/custom-cont-init.d/defaults
+++ b/docker/root/custom-cont-init.d/defaults
@@ -24,8 +24,24 @@ chown -R ${PUID:-abc}:${PGID:-abc} \
 # always create empty cron log file on start
 echo "" > "$LOGS_TO_STDOUT"
 
+# update command reference:
+# https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip
+if [ "$UPDATE_YT_DLP_ON_START" == "stable" ] ; then
+    echo "UPDATE_YT_DLP_ON_START is set to stable, attempting to update to a new stable version of yt-dlp if it exists."
+    python3 -m pip install -U "yt-dlp[default]" --break-system-packages
+elif [ "$UPDATE_YT_DLP_ON_START" == "nightly" ] ; then
+    echo "UPDATE_YT_DLP_ON_START is set to nightly, attempting to update to the latest nightly version of yt-dlp."
+    python3 -m pip install -U --pre "yt-dlp[default]"
+elif [ "$UPDATE_YT_DLP_ON_START" == "master" ] ; then
+    echo "UPDATE_YT_DLP_ON_START is set to master, pulling yt-dlp's latest commit for install."
+    python3 -m pip install -U pip hatchling wheel
+    python3 -m pip install --force-reinstall "yt-dlp[default] @ https://github.com/yt-dlp/yt-dlp/archive/master.tar.gz"
+else
+  echo "UPDATE_YT_DLP_ON_START is not set, using packaged version."
+fi
+
 # set up cron
-if [ "$CRON_SCHEDULE" != "" ] ; then
+if [ "$CRON_SCHEDULE" == "" ] ; then
     [[ ! -e "$CRON_SCRIPT" ]] && \
     cp /defaults/cron "$CRON_SCRIPT"
 

--- a/docs/source/guides/install/docker.rst
+++ b/docs/source/guides/install/docker.rst
@@ -113,6 +113,22 @@ host. The following command is for the gui image:
 See `the Docker reference <https://docs.docker.com/engine/reference/run/>`_ for further
 details.
 
+Environment Variables
+---------------------
+``ytdl-sub`` docker images support the following environment variables.
+
+.. csv-table:: Docker Environment Variables
+   :header: "Name", "Supported Values", "Description"
+   :widths: 15, 10, 60
+
+   "``PUID``", "integer", "User ID"
+   "``PGID``", "integer", "Group ID"
+   "``TZ``", "timezone", "Optional. Timezone to use in the logs. For supported values, see this `list <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>`_. "
+   "``CRON_SCHEDULE``", "cron schedule `format <https://crontab.guru/#0_*/6_*_*_*>`_", "Optional. Schedule to run the ``cron`` file in ytdl-sub's container. More info :ref:`here <guides/getting_started/automating_downloads:docker and unraid>`."
+   "``CRON_RUN_ON_START``", "true/false", "Optional. Whether to run the cron script on container start."
+   "``UPDATE_YT_DLP_ON_START``", "stable/nightly/master", "Optional. Whether to update yt-dlp to the latest configured version on container start."
+
+For the GUI image, you can set LSIO's underlying code-server `env variables <https://docs.linuxserver.io/images/docker-code-server/#environment-variables-e>`_ as well."
 
 Configuration
 -------------


### PR DESCRIPTION
For docker images, add the ability to set the variable `UPDATE_YT_DLP_ON_START`, which will update yt-dlp to the specified version if a new one exists.

Supports ``stable``,  ``nightly``, ``master``.