### PR TITLE
[DOCKER] Do not remove pip for headless image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,6 @@ RUN mkdir -pv "${DEFAULT_WORKSPACE}" && \
       g++ \
       make \
       libffi-dev \
-      py3-pip \
       py3-setuptools
 
 ###############################################################################


### PR DESCRIPTION
Closes https://github.com/jmbannon/ytdl-sub/issues/1346

Keeps pip in the image to be able to update yt-dlp