### PR TITLE
[BUGFIX] Embedded null byte ffmpeg fix

### DIFF
--- a/src/ytdl_sub/utils/ffmpeg.py
+++ b/src/ytdl_sub/utils/ffmpeg.py
@@ -203,7 +203,7 @@ def add_ffmpeg_metadata_key_values(file_path: str, key_values: Dict[str, str]) -
     for key, value in key_values.items():
         # Some special characters (utf-16 maybe?) have null-byte
         # which results in ffmpeg error, remove them outright
-        value_null_byte_removed = value.replace('\0', '')
+        value_null_byte_removed = value.replace("\0", "")
         ffmpeg_args.extend(["-metadata", f"{key}={value_null_byte_removed}"])
 
     ffmpeg_args.extend(["-codec", "copy", "-bitexact", tmp_file_path])


### PR DESCRIPTION
Closes https://github.com/jmbannon/ytdl-sub/issues/710

Fixes the notorious embedded null byte error seen during FFMPEG metadata writes when handling special characters.