### PR TITLE
[DOCKER] Disable pip break-system-packages globally in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,8 +46,10 @@ RUN mkdir -pv "${DEFAULT_WORKSPACE}" && \
       phantomjs --version && \
       cd -; \
     fi && \
+    # Configure pip globally
+    echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
     # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install --break-system-packages --no-cache-dir ytdl_sub-*.whl && \
+    python3 -m pip install ytdl_sub-*.whl && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \

--- a/docker/Dockerfile.gui
+++ b/docker/Dockerfile.gui
@@ -65,8 +65,10 @@ RUN mkdir -p /config && \
     # Install Deno, required for YouTube downloads
     curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s -- -y --no-modify-path && \
     deno --help && \
+    # Configure pip globally
+    echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
     # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install --no-cache-dir --break-system-packages ytdl_sub-*.whl && \
+    python3 -m pip install ytdl_sub-*.whl && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -68,8 +68,10 @@ RUN mkdir -pv "${DEFAULT_WORKSPACE}" && \
     # Install Deno, required for YouTube downloads
     curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s -- -y --no-modify-path && \
     deno --help && \
+    # Configure pip globally
+    echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
     # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install --no-cache-dir --break-system-packages ytdl_sub-*.whl && \
+    python3 -m pip install ytdl_sub-*.whl && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \

--- a/docker/root/custom-cont-init.d/defaults
+++ b/docker/root/custom-cont-init.d/defaults
@@ -28,14 +28,14 @@ echo "" > "$LOGS_TO_STDOUT"
 # https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip
 if [ "$UPDATE_YT_DLP_ON_START" == "stable" ] ; then
     echo "UPDATE_YT_DLP_ON_START is set to stable, attempting to update to a new stable version of yt-dlp if it exists."
-    python3 -m pip install -U "yt-dlp[default]" --break-system-packages --root-user-action=ignore
+    python3 -m pip install -U "yt-dlp[default]" 
 elif [ "$UPDATE_YT_DLP_ON_START" == "nightly" ] ; then
     echo "UPDATE_YT_DLP_ON_START is set to nightly, attempting to update to the latest nightly version of yt-dlp."
-    python3 -m pip install -U --pre "yt-dlp[default]" --root-user-action=ignore
+    python3 -m pip install -U --pre "yt-dlp[default]"
 elif [ "$UPDATE_YT_DLP_ON_START" == "master" ] ; then
     echo "UPDATE_YT_DLP_ON_START is set to master, pulling yt-dlp's latest commit for install."
-    python3 -m pip install -U pip hatchling wheel --root-user-action=ignore
-    python3 -m pip install --force-reinstall "yt-dlp[default] @ https://github.com/yt-dlp/yt-dlp/archive/master.tar.gz" --root-user-action=ignore
+    python3 -m pip install -U pip hatchling wheel
+    python3 -m pip install --force-reinstall "yt-dlp[default] @ https://github.com/yt-dlp/yt-dlp/archive/master.tar.gz"
 else
     echo "UPDATE_YT_DLP_ON_START is not set, using packaged version."
 fi


### PR DESCRIPTION
`UPDATE_YT_DLP_ON_START` doesn't work when set to 'nightly' as the pip command is missing `--break-system-packages`. https://github.com/jmbannon/ytdl-sub/blob/c3ca3c6379c264acfa6bdd444c2ca427eb9f2ec0/docker/root/custom-cont-init.d/defaults#L34 

Instead of adding it there, set `break-system-packages`, `root-user-action`, and `no-cache-dir` globally.

This pull request updates the Docker build process and initialization scripts to improve pip configuration and streamline Python package installation. The main changes ensure consistent global pip settings across all Docker images and remove redundant pip flags from individual install commands.

**Dockerfile improvements:**

* Added a global pip configuration file `/etc/pip.conf` in all Dockerfiles (`docker/Dockerfile`, `docker/Dockerfile.gui`, `docker/Dockerfile.ubuntu`) to set `break-system-packages`, `root-user-action`, and `no-cache-dir` options for all pip operations. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR49-R54) [[2]](diffhunk://#diff-136e98403c09c083a0304d0a17c0aff30ab8d931178af4a86769cf45aa74dc2eR68-R73) [[3]](diffhunk://#diff-88f82b6328bbc4e858a78f7aa00fde804b156bc8fad1aaaaa61ab2c44d5f8cedR71-R76)
* Simplified the installation command for the `ytdl-sub` wheel by removing redundant pip flags, relying on the global configuration instead. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR49-R54) [[2]](diffhunk://#diff-136e98403c09c083a0304d0a17c0aff30ab8d931178af4a86769cf45aa74dc2eR68-R73) [[3]](diffhunk://#diff-88f82b6328bbc4e858a78f7aa00fde804b156bc8fad1aaaaa61ab2c44d5f8cedR71-R76)

**Initialization script changes:**

* Removed unnecessary pip flags from the `yt-dlp` update logic in `docker/root/custom-cont-init.d/defaults`, since global pip configuration now handles these options.