### PR TITLE
[DOCKER] Add curl-cffi and yt-dlp-ejs dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,8 +48,8 @@ RUN mkdir -pv "${DEFAULT_WORKSPACE}" && \
     fi && \
     # Configure pip globally
     echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
-    # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install ytdl_sub-*.whl && \
+    # Install ytdl-sub and yt-dlp dependencies, ensure they are installed properly
+    python3 -m pip install ytdl_sub-*.whl curl-cffi yt-dlp-ejs && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \

--- a/docker/Dockerfile.gui
+++ b/docker/Dockerfile.gui
@@ -67,8 +67,8 @@ RUN mkdir -p /config && \
     deno --help && \
     # Configure pip globally
     echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
-    # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install ytdl_sub-*.whl && \
+    # Install ytdl-sub and yt-dlp dependencies, ensure they are installed properly
+    python3 -m pip install ytdl_sub-*.whl curl-cffi yt-dlp-ejs && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -70,8 +70,8 @@ RUN mkdir -pv "${DEFAULT_WORKSPACE}" && \
     deno --help && \
     # Configure pip globally
     echo -e "[global]\nbreak-system-packages = true\nroot-user-action = ignore\nno-cache-dir = true" > /etc/pip.conf && \
-    # Install ytdl-sub, ensure it is installed properly
-    python3 -m pip install ytdl_sub-*.whl && \
+    # Install ytdl-sub and yt-dlp dependencies, ensure they are installed properly
+    python3 -m pip install ytdl_sub-*.whl curl-cffi yt-dlp-ejs && \
       ytdl-sub -h && \
     # Delete unneeded packages after install
     rm ytdl_sub-*.whl && \


### PR DESCRIPTION
It looks like yt-dlp now recommends `curl-cffi` ([docs](https://github.com/yt-dlp/yt-dlp#impersonation)) and `yt-dlp-ejs` for deciphering YouTube n/sig values ([dependencies](https://github.com/yt-dlp/yt-dlp#strongly-recommended)). 

It's difficult to be 100% sure, but it does /appear/ that installing the packages reduces 429 errors.
Either way, it does remove the warning in yt-dlp, so it's probably worth doing with little downside?

## Example logs without these packages:

```
[ytdl-sub:yt-dlp] WARNING: The extractor specified to use impersonation for this download, but no impersonate target is available.
[ytdl-sub:yt-dlp] WARNING: Unable to download video subtitles for 'en': HTTP Error 429: Too Many Requests
[ytdl-sub:yt-dlp] WARNING: [youtube] nsig extraction failed: Some formats may be missing
```

## References

- yt-dlp impersonation docs: https://github.com/yt-dlp/yt-dlp#impersonation
- yt-dlp dependencies: https://github.com/yt-dlp/yt-dlp#dependencies
- Related yt-dlp announcement on YouTube changes: https://github.com/yt-dlp/yt-dlp/issues/12482