### PR TITLE
Ensure correct cron log file permissions

### DIFF
--- a/docker/root/custom-cont-init.d/defaults
+++ b/docker/root/custom-cont-init.d/defaults
@@ -17,12 +17,12 @@ echo "Starting ytdl-sub..."
   echo "alias ls='ls --color=auto'" > /config/.bashrc && \
   echo "cd ." >> /config/.bashrc
 
+# always create empty cron log file on start
+echo "" > "$LOGS_TO_STDOUT"
+
 # permissions
 chown -R ${PUID:-abc}:${PGID:-abc} \
     /config
-
-# always create empty cron log file on start
-echo "" > "$LOGS_TO_STDOUT"
 
 # update command reference:
 # https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip


### PR DESCRIPTION
# Description

When container is first started, `.cron.log` file doesn't exist yet and is created in `defaults` script [here](https://github.com/jmbannon/ytdl-sub/blob/2c33c3b49b0f7d43015352d2f5a94995ca371b9c/docker/root/custom-cont-init.d/defaults#L24-L25). 

But this happens after changing owner on the `/config` directory, leaving `root` as the owner of the log file.

This causes an error, when running container as a different user (via `PUID`, `PGID` env vars), because it cannot write logs to the file owned by root.

# Reproduction

<details><summary>compose file</summary>
<p>

Edited entrypoint to show/make sure that log file doesn't exist when starting the container

```yaml
# compose.yaml
services:
  current:
    image: ytdl-sub:local
    container_name: ytdl-sub-current
    pull_policy: never
    restart: no
    environment:
      PUID: "1000"
      PGID: "1000"
      CRON_SCHEDULE: "* */6 * * *"
      CRON_RUN_ON_START: true
    entrypoint: "/entrypoint"
    configs:
      - source: entrypoint
        target: "/entrypoint"
        uid: "1000"
        gid: "1000"
        mode: 0o540
      - source: ytdl-cron
        target: "/config/cron"
        uid: "1000"
        gid: "1000"
        mode: 0o640
configs:
  entrypoint:
    # language=bash
    content: |
      #!/usr/bin/env bash
      ls -la /config
      exec /init
  ytdl-cron:
    # language=bash
    content: |
      ls -la /config
```

</p>
</details> 

```bash
make docker # or use latest image from ghcr
docker volume prune --force  # remove anonymous volume created via dockerfile `VOLUME` command
docker compose down -v --remove-orphans  # clean up compose resources
docker compose up --force-recreate
```

Logs show, that container cannot run cron command (in my experience it either gets stuck or reports permission error)

<details><summary>Logs</summary>
<p>

```txt
total 4
drwxr-xr-x 1 root root   8 Nov  9 16:42 .
drwxr-xr-x 1 root root  20 Nov  9 16:42 ..
-rw-r----- 1 1000 users 15 Nov  9  2025 cron
[custom-init] No custom services found, skipping...
[mod-init] Running Docker Modification Logic
[mod-init] Adding linuxserver/mods:universal-stdout-logs to container
[mod-init] Downloading linuxserver/mods:universal-stdout-logs from lscr.io
[mod-init] Installing linuxserver/mods:universal-stdout-logs
[mod-init] linuxserver/mods:universal-stdout-logs applied to container
[mod-init] Adding linuxserver/mods:universal-cron to container
[mod-init] Downloading linuxserver/mods:universal-cron from lscr.io
[mod-init] Installing linuxserver/mods:universal-cron
[mod-init] linuxserver/mods:universal-cron applied to container
[migrations] started
[migrations] no migrations found
――――――――――――――――――――――――――――――――――――
██╗   ██╗████████╗██████╗ ██╗
╚██╗ ██╔╝╚══██╔══╝██╔══██╗██║
 ╚████╔╝    ██║   ██║  ██║██║
  ╚██╔╝     ██║   ██║  ██║██║
   ██║      ██║   ██████╔╝███████╗
   ╚═╝      ╚═╝   ╚═════╝ ╚══════╝

    ███████╗██╗   ██╗██████╗
    ██╔════╝██║   ██║██╔══██╗
    ███████╗██║   ██║██████╔╝
    ╚════██║██║   ██║██╔══██╗
    ███████║╚██████╔╝██████╔╝
    ╚══════╝ ╚═════╝ ╚═════╝
――――――――――――――――――――――――――――――――――――
To support LSIO projects visit:
https://www.linuxserver.io/donate/

───────────────────────────────────────
GID/UID
───────────────────────────────────────

User UID:    1000
User GID:    1000
───────────────────────────────────────
[custom-init] Files found, executing
[custom-init] defaults: executing...
Starting ytdl-sub...
UPDATE_YT_DLP_ON_START is not set, using packaged version.
Cron enabled with schedule * */6 * * *
Running cron script on start in the background
[custom-init] defaults: exited 0
Executing: tail -Fc0 /config/.cron.log
[ls.io-init] done.
```

Nothing happens after that

</p>
</details> 

# Fixed behaviour

Using the same steps as above, but with patched image get the following logs

<details><summary>Logs</summary>
<p>

```txt
total 4
drwxr-xr-x 1 root root   8 Nov  9 16:42 .
drwxr-xr-x 1 root root  20 Nov  9 16:42 ..
-rw-r----- 1 1000 users 15 Nov  9  2025 cron
[custom-init] No custom services found, skipping...
[mod-init] Running Docker Modification Logic
[mod-init] Adding linuxserver/mods:universal-stdout-logs to container
[mod-init] Downloading linuxserver/mods:universal-stdout-logs from lscr.io
[mod-init] Installing linuxserver/mods:universal-stdout-logs
[mod-init] linuxserver/mods:universal-stdout-logs applied to container
[mod-init] Adding linuxserver/mods:universal-cron to container
[mod-init] Downloading linuxserver/mods:universal-cron from lscr.io
[mod-init] Installing linuxserver/mods:universal-cron
[mod-init] linuxserver/mods:universal-cron applied to container
[migrations] started
[migrations] no migrations found
――――――――――――――――――――――――――――――――――――
██╗   ██╗████████╗██████╗ ██╗
╚██╗ ██╔╝╚══██╔══╝██╔══██╗██║
 ╚████╔╝    ██║   ██║  ██║██║
  ╚██╔╝     ██║   ██║  ██║██║
   ██║      ██║   ██████╔╝███████╗
   ╚═╝      ╚═╝   ╚═════╝ ╚══════╝

    ███████╗██╗   ██╗██████╗
    ██╔════╝██║   ██║██╔══██╗
    ███████╗██║   ██║██████╔╝
    ╚════██║██║   ██║██╔══██╗
    ███████║╚██████╔╝██████╔╝
    ╚══════╝ ╚═════╝ ╚═════╝
――――――――――――――――――――――――――――――――――――
To support LSIO projects visit:
https://www.linuxserver.io/donate/

───────────────────────────────────────
GID/UID
───────────────────────────────────────

User UID:    1000
User GID:    1000
───────────────────────────────────────
[custom-init] Files found, executing
[custom-init] defaults: executing...
Starting ytdl-sub...
UPDATE_YT_DLP_ON_START is not set, using packaged version.
Cron enabled with schedule * */6 * * *
Running cron script on start in the background
[custom-init] defaults: exited 0
Executing: tail -Fc0 /config/.cron.log
[ls.io-init] done.
total 24
drwxr-xr-x 1 abc  users  156 Nov  9 16:42 .
drwxr-xr-x 1 root root   214 Nov  9 16:42 ..
-rw-r--r-- 1 abc  users   32 Nov  9 16:42 .bashrc
-rw-r--r-- 1 abc  users    1 Nov  9 16:42 .cron.log
-rwxr-xr-x 1 abc  users  136 Nov  9 16:42 .cron_wrapper
-rw-r--r-- 1 abc  users 1056 Nov  9 16:42 config.yaml
-rwxr-x--x 1 abc  users   15 Nov  9 16:42 cron
drwxr-xr-x 1 abc  users   14 Nov  9 16:42 crontabs
drwxr-xr-x 1 abc  users  194 Nov  9 16:42 examples
-rw-r--r-- 1 abc  users 3042 Nov  9 16:42 subscriptions.yaml
```

</p>
</details> 

# Notes

It's important to start fresh, when testing, because if the previous run was from root (no `PUID`) then the file will be present and owner will be set in `defaults` script.