### PR TITLE
[FEATURE] Multi-url support for seasons in TV Show Collection presets

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
+++ b/src/ytdl_sub/prebuilt_presets/tv_show/tv_show_collection.yaml
@@ -214,10 +214,6 @@ presets:
         variables:
           collection_season_number: "2"
           collection_season_name: "{collection_season_2_name}"
-      - url: "{s02_url10}"
-        variables:
-          collection_season_number: "2"
-          collection_season_name: "{collection_season_2_name}"
 
       - url: "{collection_season_3_url}"
         variables:


### PR DESCRIPTION
Ability to use single url or array of URLs interchangeably: 
```
s01_name: "Custom First Season"
s01_urls:
   - "https://...."
   - "https://..."
s02_name: "Second"
s02_url: "https://..."
```

Supports 40 seasons, with up to 9 urls per season.