### PR TITLE
[BUGFIX] Fix custom function lambda variable dependency issue

### DIFF
--- a/src/ytdl_sub/script/types/variable_dependency.py
+++ b/src/ytdl_sub/script/types/variable_dependency.py
@@ -114,6 +114,7 @@ class VariableDependency(ABC):
                 output.add(ParsedCustomFunction(name=arg.name, num_input_args=len(arg.args)))
             if isinstance(arg, VariableDependency):
                 output.update(arg.custom_functions)
+            # if isinstance(arg, Lambda)
 
         return output
 
@@ -189,7 +190,17 @@ class VariableDependency(ABC):
         -------
         True if it contains any of the input variables. False otherwise.
         """
-        for custom_function in self.custom_functions:
+        # If there are lambdas, see if they are custom functions. If so, check them
+        custom_functions_to_check = self.custom_functions
+        for lambda_func in self.lambdas:
+            if lambda_func.value in custom_function_definitions:
+                custom_functions_to_check.add(
+                    ParsedCustomFunction(
+                        name=lambda_func.value, num_input_args=lambda_func.num_input_args()
+                    )
+                )
+
+        for custom_function in custom_functions_to_check:
             if custom_function_definitions[custom_function.name].contains(
                 variables=variables, custom_function_definitions=custom_function_definitions
             ):

--- a/tests/unit/script/functions/test_array_functions.py
+++ b/tests/unit/script/functions/test_array_functions.py
@@ -62,28 +62,6 @@ class TestArrayFunctions:
         output = single_variable_output("{%array_apply(['a', 'b', 'c'], %capitalize)}")
         assert output == ["A", "B", "C"]
 
-    def test_array_apply_custom_function(self):
-        output = (
-            Script(
-                {
-                    "the_array": "{ ['a', 'B', 'c', 'D'] }",
-                    "output": "{ %array_apply(the_array, %custom_cap) }",
-                    "should_lower": "{%bool(True)}",
-                    "%custom_cap": """{
-                        %if(
-                            %bool(should_lower),
-                            %lower($0),
-                            %upper($0)
-                        )
-                    }""",
-                }
-            )
-            .resolve(update=True)
-            .get("output")
-            .native
-        )
-        assert output == ['a', 'b', 'c', 'd']
-
     def test_array_reduce(self):
         output = single_variable_output("{%array_reduce([1, 2, 3, 4], %add)}")
         assert output == 10

--- a/tests/unit/script/types/test_lambda_function.py
+++ b/tests/unit/script/types/test_lambda_function.py
@@ -76,6 +76,28 @@ class TestLambdaFunction:
 
         assert script.resolve().get("category_url_map").native == {1: 1, 2: 2, 3: 3}
 
+    def test_array_apply_custom_function(self):
+        output = (
+            Script(
+                {
+                    "the_array": "{ ['a', 'B', 'c', 'D'] }",
+                    "output": "{ %array_apply(the_array, %lower) }",
+                    "should_lower": "{%bool(True)}",
+                    "%custom_cap": """{
+                        %if(
+                            %bool(should_lower),
+                            %lower($0),
+                            %upper($0)
+                        )
+                    }""",
+                }
+            )
+            .resolve(update=True)
+            .get("output")
+            .native
+        )
+        assert output == ["a", "b", "c", "d"]
+
 
 class TestLambdaFunctionIncompatibleNumArguments:
     @pytest.mark.parametrize(


### PR DESCRIPTION
There was a bug that did not properly check variable dependency when using lambda functions. It could still work depending on order of definitions. This fix should make it work no matter the order.