### PR TITLE
[BUGFIX] Fix Soundcloud not downloading non-album tracks

### DIFF
--- a/src/ytdl_sub/prebuilt_presets/music/soundcloud.yaml
+++ b/src/ytdl_sub/prebuilt_presets/music/soundcloud.yaml
@@ -8,7 +8,7 @@ presets:
       urls:
         # The first URL will be all the artist's tracks.
         # Treat these as singles - an album with a single track
-        - url: "{url}/tracks"
+        - url: "{url}"
           include_sibling_metadata: False
           variables:
             sc_track_album: "{title}"


### PR DESCRIPTION
The /tracks URL is currently broken in yt-dlp. Now uses the input URL which will download the entire artists' page instead to get non-album tracks.