### PR TITLE
Update first_config.rst to fix invalid `inspect` command

### DIFF
--- a/docs/source/guides/getting_started/first_config.rst
+++ b/docs/source/guides/getting_started/first_config.rst
@@ -251,7 +251,7 @@ You can unpack any subscription using the ``inspect`` sub-command to see its boi
 
 .. code-block:: bash
 
-   ytdl-sub inspect --config /path/to/config.yaml --match "BBC News" /path/to/subscriptions.yaml
+   ytdl-sub inspect --match "BBC News" /path/to/subscriptions.yaml
 
 This can be utilized for numerous purposes including:
 


### PR DESCRIPTION
Remove invalid CLI args in example

As far as I can tell from the `--help` reference on `inspect` (and the fact that I couldn't get this to work 😅), I don't think specifying the config path in the `inspect` command is valid?

---

```
usage: ytdl-sub inspect [-h] [-l 0,1,2,3] [-m MATCH [MATCH ...]] [-o DL_OVERRIDE] [-k VAR=VALUE] [SUBPATH ...]

positional arguments:
  SUBPATH               path to subscription files, uses subscriptions.yaml if not provided

options:
  -h, --help            show this help message and exit
  -l 0,1,2,3, --level 0,1,2,3
                        level of inspection to perform:
                            0 - original   present the subscription as-is
                            1 - fill       fill in defined values
                            2 - resolve    resolve all possible variables (default)
                            3 - internal   resolve all variables to their internal representation
                            
  -m MATCH [MATCH ...], --match MATCH [MATCH ...]
                        match subscription names to one or more substrings, and only run those subscriptions
  -o DL_OVERRIDE, --dl-override DL_OVERRIDE
                        override all subscription config values using `dl` syntax, i.e. --dl-override='--ytdl_options.max_downloads 3'
  -k VAR=VALUE, --mock VAR=VALUE
                        ability to mock one or more variable values, i.e. --mock 'title=Lets Play'
```