### PR TITLE
[BUGFIX] Fix output sanitization type checking

### DIFF
--- a/src/ytdl_sub/script/utils/type_checking.py
+++ b/src/ytdl_sub/script/utils/type_checking.py
@@ -7,8 +7,11 @@ from typing import Callable, List, Optional, Type, TypeVar, Union, get_origin
 
 from ytdl_sub.script.types.resolvable import (
     Argument,
+    Boolean,
     BuiltInFunctionType,
+    Float,
     FutureResolvable,
+    Integer,
     Lambda,
     LambdaReduce,
     LambdaThree,
@@ -247,6 +250,17 @@ class FunctionSpec:
         if l_type := self.is_lambda_function:
             return l_type
         return None
+
+    def has_sanitized_output(self) -> bool:
+        """
+        Returns
+        -------
+        If this function were to be sanitized, whether it's redundant or not based on its
+        output
+        """
+        return inspect.isclass(self.return_type) and issubclass(
+            self.return_type, (Integer, Float, Boolean)
+        )
 
     @classmethod
     def _to_human_readable_name(cls, python_type: Type[NamedType] | Type[Union[NamedType]]) -> str:

--- a/src/ytdl_sub/utils/script.py
+++ b/src/ytdl_sub/utils/script.py
@@ -134,28 +134,28 @@ class ScriptUtils:
             return None
 
         output = ""
-        for sub_arg in arg.args:
-            if isinstance(sub_arg, Variable):
-                # No need to sanitize built-in integer variables
-                if isinstance(VARIABLES.get(sub_arg.name), (IntegerVariable, BooleanVariable)):
-                    output += f"{{ {sub_arg.name} }}"
+        try:
+            for sub_arg in arg.args:
+                if isinstance(sub_arg, Variable):
+                    # No need to sanitize built-in integer variables
+                    if isinstance(VARIABLES.get(sub_arg.name), (IntegerVariable, BooleanVariable)):
+                        output += f"{{ {sub_arg.name} }}"
+                    else:
+                        output += f"{{ {sub_arg.name}_sanitized }}"
+                elif isinstance(sub_arg, (Integer, Float, Boolean)):
+                    output += str(sub_arg.native)
+                elif isinstance(sub_arg, String):
+                    output += CustomFunctions.sanitize(sub_arg).native
+                elif isinstance(sub_arg, BuiltInFunction) and (
+                    sub_arg.function_spec.has_sanitized_output() or sub_arg.name == "pad_zero"
+                ):
+                    # If we know the function's output is sanitized, let's not wrap it
+                    output += cls._to_script_code(sub_arg, top_level=True)
                 else:
-                    output += f"{{ {sub_arg.name}_sanitized }}"
-            elif isinstance(sub_arg, (Integer, Float, Boolean)):
-                output += str(sub_arg.native)
-            elif isinstance(sub_arg, String):
-                output += CustomFunctions.sanitize(sub_arg).native
-            elif isinstance(sub_arg, BuiltInFunction) and (
-                issubclass(sub_arg.function_spec.return_type, (Integer, Float, Boolean))
-                or sub_arg.name == "pad_zero"
-            ):
-                # If we know the function's output is sanitized, let's not wrap it
-                output += cls._to_script_code(sub_arg, top_level=True)
-            else:
-                # Purposefully do not set top_level to True so we do not recurse
-                output += (
-                    f"{{ {cls._to_script_code(BuiltInFunction(name='sanitize', args=[sub_arg]))} }}"
-                )
+                    # Purposefully do not set top_level to True so we do not recurse
+                    output += f"{{ {cls._to_script_code(BuiltInFunction(name='sanitize', args=[sub_arg]))} }}"
+        except TypeError:
+            print("huh")
 
         return output
 

--- a/src/ytdl_sub/utils/script.py
+++ b/src/ytdl_sub/utils/script.py
@@ -134,28 +134,27 @@ class ScriptUtils:
             return None
 
         output = ""
-        try:
-            for sub_arg in arg.args:
-                if isinstance(sub_arg, Variable):
-                    # No need to sanitize built-in integer variables
-                    if isinstance(VARIABLES.get(sub_arg.name), (IntegerVariable, BooleanVariable)):
-                        output += f"{{ {sub_arg.name} }}"
-                    else:
-                        output += f"{{ {sub_arg.name}_sanitized }}"
-                elif isinstance(sub_arg, (Integer, Float, Boolean)):
-                    output += str(sub_arg.native)
-                elif isinstance(sub_arg, String):
-                    output += CustomFunctions.sanitize(sub_arg).native
-                elif isinstance(sub_arg, BuiltInFunction) and (
-                    sub_arg.function_spec.has_sanitized_output() or sub_arg.name == "pad_zero"
-                ):
-                    # If we know the function's output is sanitized, let's not wrap it
-                    output += cls._to_script_code(sub_arg, top_level=True)
+        for sub_arg in arg.args:
+            if isinstance(sub_arg, Variable):
+                # No need to sanitize built-in integer variables
+                if isinstance(VARIABLES.get(sub_arg.name), (IntegerVariable, BooleanVariable)):
+                    output += f"{{ {sub_arg.name} }}"
                 else:
-                    # Purposefully do not set top_level to True so we do not recurse
-                    output += f"{{ {cls._to_script_code(BuiltInFunction(name='sanitize', args=[sub_arg]))} }}"
-        except TypeError:
-            print("huh")
+                    output += f"{{ {sub_arg.name}_sanitized }}"
+            elif isinstance(sub_arg, (Integer, Float, Boolean)):
+                output += str(sub_arg.native)
+            elif isinstance(sub_arg, String):
+                output += CustomFunctions.sanitize(sub_arg).native
+            elif isinstance(sub_arg, BuiltInFunction) and (
+                sub_arg.function_spec.has_sanitized_output() or sub_arg.name == "pad_zero"
+            ):
+                # If we know the function's output is sanitized, let's not wrap it
+                output += cls._to_script_code(sub_arg, top_level=True)
+            else:
+                # Purposefully do not set top_level to True so we do not recurse
+                output += (
+                    f"{{ {cls._to_script_code(BuiltInFunction(name='sanitize', args=[sub_arg]))} }}"
+                )
 
         return output
 


### PR DESCRIPTION
In the inspection output, we check function's return types via issubclass to see if an optimization can be made. Guard against this check in case the return type isn't a class -- it could be a Union[..., ...] from a conditional.